### PR TITLE
Avoid leaking memory or leaving it corrupt

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -484,6 +484,7 @@ apteryx_set (const char *path, const char *value)
     if (!path || path[strlen(path) - 1] == '/')
     {
         ERROR ("SET: invalid path (%s)!\n", path);
+        free (url);
         assert (!debug || path);
         return false;
     }
@@ -605,6 +606,7 @@ apteryx_get (const char *path)
     if (!path || path[strlen(path)-1] == '/')
     {
         ERROR ("GET: invalid path (%s)!\n", path);
+        free (url);
         assert (!debug || path);
         return NULL;
     }
@@ -996,6 +998,7 @@ apteryx_search (const char *path)
     if (!path)
     {
         ERROR ("SEARCH: invalid root (%s)!\n", path);
+        free (url);
         assert (!debug || path);
         return false;
     }
@@ -1159,7 +1162,10 @@ handle_timestamp_response (const Apteryx__TimeStampResult *result, void *closure
     {
         ERROR ("TIMESTAMP: Error processing request.\n");
     }
-    *data = result->value;
+    else
+    {
+        *data = result->value;
+    }
 }
 
 uint64_t
@@ -1179,6 +1185,7 @@ apteryx_timestamp (const char *path)
         ((path[strlen(path)-1] == '/') && strlen(path) > 1))
     {
         ERROR ("TIMESTAMP: invalid path (%s)!\n", path);
+        free (url);
         assert (!debug || path);
         return 0;
     }

--- a/database.c
+++ b/database.c
@@ -169,7 +169,9 @@ db_node_delete (struct database_node *node)
             g_list_free (children);
         }
         free (node->value);
+        node->value = NULL;
         free (node->key);
+        node->key = NULL;
         if (node == root)
             root = NULL;
         free (node);
@@ -288,11 +290,8 @@ db_add (const char *path, const unsigned char *value, size_t length)
     }
     pthread_rwlock_wrlock (&db_lock);
     free (new_value->value);
-    if (length == 0)
-    {
-        new_value->value = NULL;
-    }
-    else
+    new_value->value = NULL;
+    if (length > 0)
     {
         new_value->value = malloc (length);
         memcpy (new_value->value, value, length);

--- a/rpc_socket.c
+++ b/rpc_socket.c
@@ -47,6 +47,7 @@ listen_thread (void *p)
             {
                 /* Shutdown */
                 DEBUG ("RPC[%i]: Shutdown\n", fd);
+                free (data);
                 goto finished;
             }
             if (r < 0)


### PR DESCRIPTION
- memory leaks found by static analysis.
- double frees were seen in database.c for node->value
- NULL pointer deref were seen in database.c for node->key