### PR TITLE
Add the ability to check if a path exists

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -674,6 +674,19 @@ apteryx_get_int (const char *path, const char *key)
     return value;
 }
 
+bool
+apteryx_exists (const char *path)
+{
+    char *value = NULL;
+    value = apteryx_get (path);
+    if (value)
+    {
+        free (value);
+        return true;
+    }
+    return false;
+}
+
 static inline gboolean
 _node_free (GNode *node, gpointer data)
 {

--- a/apteryx.h
+++ b/apteryx.h
@@ -136,6 +136,14 @@ char *apteryx_get_string (const char *path, const char *key);
 int32_t apteryx_get_int (const char *path, const char *key);
 
 /**
+ * Check if a path exists in Apteryx
+ * @param path path to check that it exists
+ * @return true if the path exists
+ * @return false if the path is invalid
+ */
+bool apteryx_exists (const char *path);
+
+/**
  * Helpers for generating and parsing an Apteryx tree.
  * Can be used to set/get multiple values at once.
  * Uses GLIB's GNode based N-ary trees.

--- a/test.c
+++ b/test.c
@@ -529,6 +529,21 @@ test_set_get_string ()
 }
 
 void
+test_set_exists ()
+{
+    const char *path = TEST_PATH"/entity/zones";
+    const char *value = "123456";
+
+    CU_ASSERT (apteryx_set (path, value));
+
+    CU_ASSERT (apteryx_exists (path) == true);
+
+    CU_ASSERT (apteryx_prune (path));
+
+    CU_ASSERT (apteryx_exists (path) == false);
+}
+
+void
 test_search_paths ()
 {
     GList *paths = NULL;
@@ -2630,6 +2645,7 @@ static CU_TestInfo tests_api[] = {
     { "multiple leaves", test_multiple_leaves },
     { "set/get string", test_set_get_string },
     { "set/get int", test_set_get_int },
+    { "exists", test_set_exists },
     { "get no value", test_get_no_value },
     { "overwrite", test_overwrite },
     { "delete", test_delete },


### PR DESCRIPTION
The new function apteryx_exists() checks if the specified path
exists.  If the path exists it returns true otherwise false.

This means that users of this function no longer need to call
apteryx_get() and free memory when they don't care about the
value.  This removes the chance of a memory leak and allows the
caller to make a single call instead of eight lines of code.