### PR TITLE
rpc_transport: mask signals in the accept thread

### DIFF
--- a/rpc_transport.c
+++ b/rpc_transport.c
@@ -75,6 +75,11 @@ parse_url (const char *url)
 static void *
 accept_thread (void *p)
 {
+    /* Mask signals */
+    sigset_t set;
+    sigfillset(&set);
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
+
     rpc_server s = (rpc_server) p;
     while (1)
     {


### PR DESCRIPTION
avoid handling signals in apteryx accept threads, or any of their
children.
All apteryx clients will have an accept thread, and this sometimes
results in their signal handlers being run this thread.
The previously single threaded processes now have race conditions
when this occurs.