### PR TITLE
rpc_transport,socket: mask signals in the accept/listen thread

### DIFF
--- a/rpc_socket.c
+++ b/rpc_socket.c
@@ -56,6 +56,11 @@ listen_thread (void *p)
 {
     rpc_socket sock = (rpc_socket) p;
 
+    /* Mask signals */
+    sigset_t set;
+    sigfillset (&set);
+    pthread_sigmask (SIG_BLOCK, &set, NULL);
+
     do
     {
         int fd = sock->sock;

--- a/rpc_transport.c
+++ b/rpc_transport.c
@@ -75,6 +75,11 @@ parse_url (const char *url)
 static void *
 accept_thread (void *p)
 {
+    /* Mask signals */
+    sigset_t set;
+    sigfillset (&set);
+    pthread_sigmask (SIG_BLOCK, &set, NULL);
+
     rpc_server s = (rpc_server) p;
     while (1)
     {


### PR DESCRIPTION
Avoid handling signals in apteryx accept threads, or any of their
children.
All apteryx clients will have an accept thread, and this sometimes
results in their signal handlers being run this thread.
The previously single threaded processes now have race conditions
when this occurs.