### PR TITLE
xml2lua: include value parameter on toplevel functions.

### DIFF
--- a/xml2lua
+++ b/xml2lua
@@ -204,7 +204,7 @@ function generate_defines(tbl, path, depth)
 			print(line)
 		elseif is_list(tbl) then
 			if depth == 0 then
-				print("apteryx[\""..name.."\"]=function(name"..depth..")")
+				print("apteryx[\""..name.."\"]=function(name"..depth..",value)")
 			else
 				print(tab.."[\""..name.."\"]".."=function(name"..depth..",value)")
 			end


### PR DESCRIPTION
The body of the function checked if value was nil to decide whether to
do a set or a get, and as it wasn't included in the parameter list, it
would check if any global variable called "value" was being set.