### PR TITLE
Add apteryx_get_tree_timeout function

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -986,7 +986,7 @@ handle_traverse_response (const Apteryx__TraverseResult *result, void *closure_d
 }
 
 GNode*
-apteryx_get_tree (const char *path)
+apteryx_get_tree_timeout (const char *path, uint64_t timeout)
 {
     char *url = NULL;
     ProtobufCService *rpc_client;
@@ -1009,7 +1009,7 @@ apteryx_get_tree (const char *path)
     }
 
     /* IPC */
-    rpc_client = rpc_client_connect (rpc, url);
+    rpc_client = rpc_client_connect_timeout (rpc, url, timeout);
     if (!rpc_client)
     {
         ERROR ("TRAVERSE: Falied to connect to server: %s\n", strerror (errno));
@@ -1031,6 +1031,12 @@ apteryx_get_tree (const char *path)
     rpc_client_release (rpc, rpc_client, true);
     free (url);
     return data.root;
+}
+
+GNode*
+apteryx_get_tree (const char *path)
+{
+    return apteryx_get_tree_timeout (path, RPC_TIMEOUT_US);
 }
 
 typedef struct _search_data_t

--- a/apteryx.h
+++ b/apteryx.h
@@ -296,6 +296,15 @@ bool apteryx_set_tree (GNode* root);
 GNode* apteryx_get_tree (const char *path);
 
 /**
+ * Get a tree of multiple values from Apteryx, using the specified
+ * timeout for the RPC.
+ * @param path path to the root of the tree to return.
+ * @param timeout timeout for the RPC.
+ * @return N-ary tree of nodes.
+ */
+GNode* apteryx_get_tree_timeout (const char *path, uint64_t timeout);
+
+/**
  * Set a tree of multiple values in Apteryx, but only if
  * the existing value has not changed since the specified timestamp.
  * @param root pointer to the N-ary tree of nodes.

--- a/internal.h
+++ b/internal.h
@@ -137,6 +137,7 @@ bool rpc_server_bind (rpc_instance rpc, const char *guid, const char *url);
 bool rpc_server_release (rpc_instance rpc, const char *guid);
 int rpc_server_process (rpc_instance rpc, bool poll);
 ProtobufCService *rpc_client_connect (rpc_instance rpc, const char *url);
+ProtobufCService *rpc_client_connect_timeout (rpc_instance rpc, const char *url, uint64_t timeout);
 void rpc_client_release (rpc_instance rpc, ProtobufCService *service, bool keep);
 
 /* Apteryx configuration */


### PR DESCRIPTION
This patch adds the function apteryx_get_tree_timeout which allows
the RPC timeout to be specified. This may be required if a tree takes
longer to get than the default timeout of 1s.

The original apteryx_get_tree now wraps apteryx_get_tree_timeout and
passes in the default timeout.

A 'timeout' field has been added to the rpc_client struct, which is
assigned the desired value before connecting to the server.