### PR TITLE
Use separate timeout value for clients

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -249,7 +249,7 @@ apteryx_init (bool debug_enabled)
         char * uri = NULL;
 
         /* Create RPC instance */
-        rpc = rpc_init ((ProtobufCService *)&apteryx_client_service, &apteryx__server__descriptor, RPC_TIMEOUT_US);
+        rpc = rpc_init ((ProtobufCService *)&apteryx_client_service, &apteryx__server__descriptor, RPC_CLIENT_TIMEOUT_US);
         if (rpc == NULL)
         {
             ERROR ("Init: Failed to initialise RPC service\n");

--- a/internal.h
+++ b/internal.h
@@ -128,6 +128,7 @@ uint64_t db_timestamp (const char *path);
 
 /* RPC API */
 #define RPC_TIMEOUT_US 1000000
+#define RPC_CLIENT_TIMEOUT_US 1000000
 typedef struct rpc_instance_s *rpc_instance;
 #define RPC_TEST_DELAY_MASK 0x7FF
 extern bool rpc_test_random_watch_delay;

--- a/rpc.c
+++ b/rpc.c
@@ -58,6 +58,7 @@ typedef struct rpc_client_t
     rpc_socket sock;
     uint32_t refcount;
     char *url;
+    uint64_t timeout;
 } rpc_client_t;
 
 /* Message header */
@@ -132,7 +133,7 @@ invoke_client_service (ProtobufCService *service,
     DEBUG ("RPC[%d]: waiting for response\n", client->sock->sock);
     void *data = NULL;
     size_t len = 0;
-    if (!rpc_socket_recv (client->sock, id, &data, &len, RPC_TIMEOUT_US))
+    if (!rpc_socket_recv (client->sock, id, &data, &len, client->timeout))
     {
         goto error;
     }
@@ -610,6 +611,7 @@ rpc_client_connect (rpc_instance rpc, const char *url)
     client->sock = sock;
     client->refcount = 1;
     client->url = g_strdup (url);
+    client->timeout = rpc->timeout;
 
     DEBUG ("RPC[%d]: New client to %s\n", sock->sock, url);
 


### PR DESCRIPTION
When calling apteryx_get_tree, the RPC times out if getting the tree
takes longer than 1s. A solution is to have a separate define for
the client-side RPC timeout value.

This patch adds a separate define for the client RPC timeout value,
RPC_CLIENT_TIMEOUT_US. When apteryx_init is called, it sets the
timeout in the rpc_instance to this value, which is then used when
communicating with apteryxd.

The behaviour of apteryxd is unchanged; it still uses the original
timeout value.