### PR TITLE
validate_path: Handle colons in the path

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -64,8 +64,8 @@ validate_path (const char *path, char **url)
     {
         if (url)
             *url = strdup (path);
-        path = strrchr (path, ':') + 1;
-        char *tmp = strrchr (*url, ':');
+        path = strstr (path + 6, ":/") + 1;
+        char *tmp = strstr (*url + 6, ":/");
         if (tmp)
         {
             tmp[0] = '\0';

--- a/test.c
+++ b/test.c
@@ -3330,6 +3330,19 @@ test_deadlock2 ()
 }
 
 void
+test_remote_path_colon ()
+{
+    char *path = TEST_TCP_URL":"TEST_PATH "/2001:db8::1/test";
+    char *value = NULL;
+    CU_ASSERT (apteryx_bind (TEST_TCP_URL));
+    usleep (TEST_SLEEP_TIMEOUT);
+    CU_ASSERT (apteryx_set (path, "hello"));
+    CU_ASSERT ((value = apteryx_get (path)) != NULL && strcmp (value, "hello") == 0);
+    free (value);
+    CU_ASSERT (apteryx_unbind (TEST_TCP_URL));
+}
+
+void
 _dump_config (FILE *fd, char *root, int tab)
 {
     GList *paths = apteryx_search (root);
@@ -3899,6 +3912,7 @@ static CU_TestInfo tests_api[] = {
     { "bitmap", test_bitmap },
     { "shutdown deadlock", test_deadlock },
     { "shutdown deadlock 2", test_deadlock2 },
+    { "remote path contains colon", test_remote_path_colon },
     CU_TEST_INFO_NULL,
 };
 


### PR DESCRIPTION
When IPv6 addresses were present in the path,
and the url was specified, the wrong path would
be sent to the remote apteryx daemon.