### PR TITLE
Rename global debug variable to be more specific

### DIFF
--- a/alfred.c
+++ b/alfred.c
@@ -41,7 +41,7 @@
 #define SECONDS_TO_MILLI 1000
 
 /* Debug */
-bool debug = false;
+bool apteryx_debug = false;
 
 /* An Alfred instance. */
 struct alfred_instance_t
@@ -1340,7 +1340,7 @@ main (int argc, char *argv[])
         switch (i)
         {
         case 'd':
-            debug = true;
+            apteryx_debug = true;
             background = false;
             break;
         case 'b':
@@ -1379,7 +1379,7 @@ main (int argc, char *argv[])
     }
 
     /* Initialise Apteryx client library */
-    apteryx_init (debug);
+    apteryx_init (apteryx_debug);
 
     cb_init ();
 

--- a/apteryx.c
+++ b/apteryx.c
@@ -36,7 +36,7 @@
 #include <glib.h>
 
 /* Configuration */
-bool debug = false;                      /* Debug enabled */
+bool apteryx_debug = false;                      /* Debug enabled */
 static const char *default_url = APTERYX_SERVER; /* Default path to Apteryx database */
 static int ref_count = 0;               /* Library reference count */
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER; /* Protect globals */
@@ -243,7 +243,7 @@ apteryx_init (bool debug_enabled)
     /* Increment refcount */
     pthread_mutex_lock (&lock);
     ref_count++;
-    debug |= debug_enabled;
+    apteryx_debug |= debug_enabled;
     if (ref_count == 1)
     {
         char * uri = NULL;
@@ -372,7 +372,7 @@ apteryx_prune (const char *path)
     if (!path)
     {
         ERROR ("PRUNE: invalid path (%s)!\n", path);
-        assert (!debug || path);
+        assert (!apteryx_debug || path);
         return false;
     }
 
@@ -462,7 +462,7 @@ apteryx_cas (const char *path, const char *value, uint64_t ts)
     {
         ERROR ("SET: invalid path (%s)!\n", path);
         free (url);
-        assert (!debug || path);
+        assert (!apteryx_debug || path);
         return false;
     }
 
@@ -609,7 +609,7 @@ apteryx_get (const char *path)
     {
         ERROR ("GET: invalid path (%s)!\n", path);
         free (url);
-        assert (!debug || path);
+        assert (!apteryx_debug || path);
         return NULL;
     }
 
@@ -863,7 +863,7 @@ apteryx_cas_tree (GNode* root, uint64_t ts)
     if (!path || path[strlen(path) - 1] == '/')
     {
         ERROR ("SET_TREE: invalid path (%s)!\n", path);
-        assert (!debug || path);
+        assert (!apteryx_debug || path);
         free (url);
         return false;
     }
@@ -1019,7 +1019,7 @@ apteryx_get_tree (const char *path)
     if (!path || path[strlen(path) - 1] == '/')
     {
         ERROR ("GET_TREE: invalid path (%s)!\n", path);
-        assert (!debug || path);
+        assert (!apteryx_debug || path);
         free (url);
         return false;
     }
@@ -1104,7 +1104,7 @@ apteryx_search (const char *path)
     {
         ERROR ("SEARCH: invalid root (%s)!\n", path);
         free (url);
-        assert (!debug || path);
+        assert (!apteryx_debug || path);
         return false;
     }
 
@@ -1123,9 +1123,9 @@ apteryx_search (const char *path)
     {
         free (url);
         ERROR ("SEARCH: invalid root (%s)!\n", path);
-        assert(!debug || path[0] == '/');
-        assert(!debug || path[strlen (path) - 1] == '/');
-        assert(!debug || strstr (path, "//") == NULL);
+        assert(!apteryx_debug || path[0] == '/');
+        assert(!apteryx_debug || path[strlen (path) - 1] == '/');
+        assert(!apteryx_debug || strstr (path, "//") == NULL);
         return NULL;
     }
 
@@ -1214,7 +1214,7 @@ apteryx_find (const char *path, const char *value)
     {
         ERROR ("FIND: invalid root (%s)!\n", path);
         free (url);
-        assert (!debug || path);
+        assert (!apteryx_debug || path);
         return false;
     }
 
@@ -1232,8 +1232,8 @@ apteryx_find (const char *path, const char *value)
     {
         free (url);
         ERROR ("FIND: invalid root (%s)!\n", path);
-        assert(!debug || path[0] == '/');
-        assert(!debug || strstr (path, "//") == NULL);
+        assert(!apteryx_debug || path[0] == '/');
+        assert(!apteryx_debug || strstr (path, "//") == NULL);
         return NULL;
     }
 
@@ -1326,8 +1326,8 @@ apteryx_find_tree (GNode *root)
     {
         free (url);
         ERROR ("FIND: invalid root (%s)!\n", path);
-        assert(!debug || path[0] == '/');
-        assert(!debug || strstr (path, "//") == NULL);
+        assert(!apteryx_debug || path[0] == '/');
+        assert(!apteryx_debug || strstr (path, "//") == NULL);
         return NULL;
     }
 
@@ -1520,7 +1520,7 @@ apteryx_timestamp (const char *path)
     {
         ERROR ("TIMESTAMP: invalid path (%s)!\n", path);
         free (url);
-        assert (!debug || path);
+        assert (!apteryx_debug || path);
         return 0;
     }
 

--- a/apteryxc.c
+++ b/apteryxc.c
@@ -28,7 +28,7 @@
 #include "apteryx.pb-c.h"
 
 /* Debug enabled */
-bool debug = false;
+bool apteryx_debug = false;
 
 /* Run while true */
 static bool running = true;
@@ -101,7 +101,7 @@ main (int argc, char **argv)
         switch (c)
         {
         case 'd':
-            debug = true;
+            apteryx_debug = true;
             break;
         case 's':
             mode = MODE_SET;
@@ -169,7 +169,7 @@ main (int argc, char **argv)
             usage ();
             return 0;
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         if ((param = apteryx_get (path)))
         {
             printf ("%s\n", param);
@@ -185,7 +185,7 @@ main (int argc, char **argv)
             usage ();
             return 0;
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         if (!apteryx_set (path, param))
             printf ("Failed\n");
         apteryx_shutdown ();
@@ -196,7 +196,7 @@ main (int argc, char **argv)
             usage ();
             return 0;
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         GList *paths = apteryx_search (path);
         for (_iter = paths; _iter; _iter = _iter->next)
             printf ("  %s\n", (char *) _iter->data);
@@ -213,7 +213,7 @@ main (int argc, char **argv)
         {
             path = "";
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         apteryx_dump (path, stdout);
         apteryx_shutdown ();
         break;
@@ -227,7 +227,7 @@ main (int argc, char **argv)
         {
             path = "/";
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         apteryx_watch (path, watch_callback);
         while (running)
             pause ();
@@ -240,7 +240,7 @@ main (int argc, char **argv)
             usage ();
             return 0;
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         provide_value = param;
         apteryx_provide (path, provide_callback);
         while (running)
@@ -254,7 +254,7 @@ main (int argc, char **argv)
             usage ();
             return 0;
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         apteryx_proxy (path, param);
         apteryx_shutdown ();
         break;
@@ -268,7 +268,7 @@ main (int argc, char **argv)
         {
             path = "";
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         value = apteryx_timestamp (path);
         printf ("%"PRIu64"\n", value);
         apteryx_shutdown ();
@@ -279,7 +279,7 @@ main (int argc, char **argv)
             usage ();
             return 0;
         }
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         run_unit_tests (filter);
         usleep (100000);
         apteryx_shutdown ();

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -30,7 +30,7 @@
 #include "internal.h"
 
 /* Debug */
-bool debug = false;
+bool apteryx_debug = false;
 
 /* Run while true */
 static bool running = true;
@@ -801,7 +801,7 @@ apteryx__set (Apteryx__Server_Service *service,
     INC_COUNTER (counters.set);
 
     /* Debug */
-    for (i=0; debug && i<set->n_sets; i++)
+    for (i=0; apteryx_debug && i<set->n_sets; i++)
     {
         DEBUG ("SET: %s = %s\n", set->sets[i]->path, set->sets[i]->value);
     }
@@ -1073,7 +1073,7 @@ apteryx__find (Apteryx__Server_Service *service,
     INC_COUNTER (counters.find);
 
     /* Debug */
-    for (i = 0; debug && i < find->n_matches; i++)
+    for (i = 0; apteryx_debug && i < find->n_matches; i++)
     {
         DEBUG ("FIND: %s = %s\n", find->matches[i]->path, find->matches[i]->value);
     }
@@ -1429,7 +1429,7 @@ main (int argc, char **argv)
         switch (i)
         {
         case 'd':
-            debug = true;
+            apteryx_debug = true;
             background = false;
             break;
         case 'b':

--- a/common.h
+++ b/common.h
@@ -34,7 +34,7 @@
 #include <glib.h>
 
 /* Debug */
-extern bool debug;
+extern bool apteryx_debug;
 
 static inline uint64_t
 get_time_us (void)
@@ -54,7 +54,7 @@ static inline uint32_t htol32 (uint32_t v)
 #define ltoh32 htol32
 
 #define DEBUG(fmt, args...) \
-    if (debug) \
+    if (apteryx_debug) \
     { \
         syslog (LOG_DEBUG, fmt, ## args); \
         printf ("[%"PRIu64":%d] ", get_time_us (), getpid ()); \
@@ -64,7 +64,7 @@ static inline uint32_t htol32 (uint32_t v)
 #define ERROR(fmt, args...) \
     { \
         syslog (LOG_ERR, fmt, ## args); \
-        if (debug) \
+        if (apteryx_debug) \
         { \
             fprintf (stderr, "[%"PRIu64":%d] ", get_time_us (), getpid ()); \
             fprintf (stderr, "ERROR: "); \
@@ -76,7 +76,7 @@ static inline uint32_t htol32 (uint32_t v)
     if (!(assertion)) \
     { \
         syslog (LOG_ERR, fmt, ## args); \
-        if (debug) \
+        if (apteryx_debug) \
         { \
             fprintf (stderr, "[%"PRIu64":%d] ", get_time_us (), getpid ()); \
             fprintf (stderr, "ASSERT: "); \

--- a/config.c
+++ b/config.c
@@ -28,10 +28,10 @@ static bool
 handle_debug_set (const char *path, const char *value)
 {
     if (value)
-        debug = atoi (value);
+        apteryx_debug = atoi (value);
     else
-        debug = false;
-    DEBUG ("DEBUG %s\n", debug ? "enabled" : "disabled");
+        apteryx_debug = false;
+    DEBUG ("DEBUG %s\n", apteryx_debug ? "enabled" : "disabled");
     return true;
 }
 

--- a/syncer.c
+++ b/syncer.c
@@ -11,7 +11,7 @@
 #define APTERYX_SYNC_CONFIG_DIR "/etc/apteryx/sync/"
 
 /* Debug */
-bool debug = false;
+bool apteryx_debug = false;
 
 /* Run while true */
 static bool running = true;
@@ -470,7 +470,7 @@ main (int argc, char *argv[])
         switch (i)
         {
         case 'd':
-            debug = true;
+            apteryx_debug = true;
             background = false;
             break;
         case 'b':

--- a/test.c
+++ b/test.c
@@ -74,7 +74,7 @@ test_init ()
     CU_ASSERT ((value = apteryx_get (path)) == NULL);
     CU_ASSERT (apteryx_set (path, NULL) == FALSE);
     CU_ASSERT (assert_apteryx_empty ());
-    apteryx_init (debug);
+    apteryx_init (apteryx_debug);
 }
 
 void
@@ -263,13 +263,13 @@ test_process_multi_write ()
         writers[i] = fork ();
         if (writers[i] == 0)
         {
-            apteryx_init (debug);
+            apteryx_init (apteryx_debug);
             _multi_write_thread ((void *) i);
             apteryx_shutdown ();
             exit (0);
         }
     }
-    apteryx_init (debug);
+    apteryx_init (apteryx_debug);
 
     for (i = 0; i < thread_count; i++)
     {
@@ -1093,7 +1093,7 @@ test_watch_fork ()
     apteryx_shutdown ();
     if ((pid = fork ()) == 0)
     {
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         usleep (TEST_SLEEP_TIMEOUT);
         apteryx_set_string (path, NULL, "down");
         apteryx_shutdown ();
@@ -1101,7 +1101,7 @@ test_watch_fork ()
     }
     else if (pid > 0)
     {
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         CU_ASSERT (apteryx_watch (path, test_watch_callback));
         usleep (TEST_SLEEP_TIMEOUT * 2);
         waitpid (pid, &status, 0);
@@ -1573,13 +1573,13 @@ test_watch_rpc_restart ()
     CU_ASSERT (apteryx_set_string (path, NULL, "up"));
     CU_ASSERT (apteryx_watch (path, test_watch_callback));
     apteryx_shutdown ();
-    apteryx_init (debug);
+    apteryx_init (apteryx_debug);
     CU_ASSERT (apteryx_set_string (path, NULL, "down"));
     usleep (TEST_SLEEP_TIMEOUT);
     CU_ASSERT (_path && strcmp (_path, path) == 0);
     CU_ASSERT (_value && strcmp (_value, "down") == 0);
     apteryx_shutdown ();
-    apteryx_init (debug);
+    apteryx_init (apteryx_debug);
     CU_ASSERT (apteryx_set_string (path, NULL, "up"));
     usleep (TEST_SLEEP_TIMEOUT);
     CU_ASSERT (_path && strcmp (_path, path) == 0);
@@ -2083,7 +2083,7 @@ test_provide_different_process ()
     apteryx_shutdown ();
     if ((pid = fork ()) == 0)
     {
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         CU_ASSERT (apteryx_provide (path, test_provide_callback_up));
         usleep (RPC_TIMEOUT_US);
         apteryx_unprovide (path, test_provide_callback_up);
@@ -2092,7 +2092,7 @@ test_provide_different_process ()
     }
     else if (pid > 0)
     {
-        apteryx_init (debug);
+        apteryx_init (apteryx_debug);
         usleep (RPC_TIMEOUT_US / 2);
         CU_ASSERT ((value = apteryx_get (path)) != NULL);
         CU_ASSERT (value && strcmp (value, "up") == 0);
@@ -3134,7 +3134,7 @@ test_proxy_tree_get ()
     CU_ASSERT (apteryx_set (TEST_PATH"/local", NULL));
     CU_ASSERT (assert_apteryx_empty ());
 
-    debug = false;
+    apteryx_debug = false;
 }
 
 void


### PR DESCRIPTION
OpenSSH has it's own function called 'debug', which conflicts with
apterxys debug flag. Trying to write to the debug variable caused a
crash. Rename it so it's more specific to reduce the chance of
conflicts.