### PR TITLE
Add a missing pthread unlock to apteryx_init

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -260,7 +260,11 @@ apteryx_init (bool debug_enabled)
 
         /* Bind to the default uri for this client */
         if (asprintf((char **)&uri, APTERYX_SERVER".%"PRIu64, (uint64_t)getpid ()) <= 0)
+        {
+            ref_count--;
+            pthread_mutex_unlock (&lock);
             return false;
+        }
         if (!rpc_server_bind (rpc, uri, uri))
         {
             ERROR ("Failed to bind to default rpc service\n");


### PR DESCRIPTION
Previously, if asprintf failed in apteryx_init, a pthread would
not unlock. This is now implemented