### PR TITLE
Make xml2c include guard defines more unique

### DIFF
--- a/xml2c
+++ b/xml2c
@@ -101,8 +101,8 @@ function generate_header(xml,filename)
     generate_help(xml)
     print(string.format([[
  */
-#ifndef __%s_H__
-#define __%s_H__
+#ifndef __%s_APTERYX_SCHEMA_H__
+#define __%s_APTERYX_SCHEMA_H__
 ]], module:upper(),module:upper()))
 end
 
@@ -167,7 +167,7 @@ function generate_footer(filename)
     module = name:gsub(".xml", "")
     print(string.format([[
 
-#endif /*__%s_H__*/
+#endif /*__%s_APTERYX_SCHEMA_H__*/
 ]], module:upper()))
 end
 


### PR DESCRIPTION
If toplevel nodes have names that are similar to other important header
files (e.g system, version, log, platform, syslog), the includes
generated by xml2c would have conflicting include guards, even if the
output of xml2c was piped to a file with a different name.

The include guard is now changed to __NODENAME_APTERYX_SCHEMA_H__

Signed-off-by: Luuk Paulussen <luuk.paulussen@alliedtelesis.co.nz>