### PR TITLE
Exclude star nodes from search results

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -989,13 +989,17 @@ search_path (const char *path)
             {
                 cb_info_t *provider = iter->data;
                 int len = strlen (path);
-                char *ptr, *path = g_strdup (provider->path);
-                if ((ptr = strchr (&path[len ? len : len+1], '/')) != 0)
+                /* If there is a provider for a single node below here it may
+                 * show as a "*" entry in this list, which is not desirable */
+                if (strchr (provider->path, '*'))
+                    continue;
+                char *ptr, *provider_path = g_strdup (provider->path);
+                if ((ptr = strchr (&provider_path[len ? len : len+1], '/')) != 0)
                     *ptr = '\0';
-                if (!g_list_find_custom (results, path, (GCompareFunc) strcmp))
-                    results = g_list_append (results, path);
+                if (!g_list_find_custom (results, provider_path, (GCompareFunc) strcmp))
+                    results = g_list_append (results, provider_path);
                 else
-                    g_free (path);
+                    g_free (provider_path);
             }
             g_list_free_full (providers, (GDestroyNotify) cb_release);
         }

--- a/test.c
+++ b/test.c
@@ -2228,9 +2228,16 @@ test_provider_wildcard_internal ()
     const char *path = TEST_PATH"/a/b/*/f";
     const char *path2 = TEST_PATH"/a/b/e/f";
     const char *path3 = TEST_PATH"/a/bcd/e/f";
+    GList *search_result = NULL;
     char *value = NULL;
 
     CU_ASSERT (apteryx_provide (path, test_provide_wildcard_callback));
+
+    /* The provided value should NOT show in search */
+    search_result = apteryx_search (TEST_PATH"/a/b/");
+    CU_ASSERT (g_list_length (search_result) == 0);
+    g_list_free_full (search_result, free);
+
     CU_ASSERT ((value = apteryx_get (path)) != NULL);
     free (value);
     CU_ASSERT ((value = apteryx_get (path2)) != NULL);


### PR DESCRIPTION
Currently if there is a field below a star node that is provided,
doing a search on the parent node will include the star node in the
search results.
e.g. If /a/b/*/f is provided, doing a search on /a/b/ will include
/a/b/* in the results.

This is undesirable because doing a search on an empty subtree should
return NULL.

This patch excludes paths containing star nodes when adding provided
paths to the search results.