### PR TITLE
rpc: Don't decrement the reference counter for dead sockets

### DIFF
--- a/rpc.c
+++ b/rpc.c
@@ -544,8 +544,6 @@ gc_clients (rpc_instance rpc)
             DEBUG ("RPC[%d]: Collecting dead socket for %s\n", client->sock->sock, client->url);
             if (client->refcount < 2)
                 client_release (rpc, client, false);
-            else
-                client->refcount--;
         }
         g_list_free (dead);
 


### PR DESCRIPTION
This was allowing in-use connections to be freed twice.
Once from the rpc_client_connect (after gc_clients saw the socket as dead)
and then another thread calling rpc_client_release,
the thread was waiting for a message while the socket died.