### PR TITLE
Return -1 for apteryx_get_int when value cannot be represented as int...

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -687,13 +687,13 @@ apteryx_get_int (const char *path, const char *key)
         len = asprintf (&full_path, "%s", path);
     if (len)
     {
+        if (apteryx_debug)
+        {
+            errno = 0;
+        }
+
         if ((v = apteryx_get (full_path)))
         {
-            if (apteryx_debug)
-            {
-                errno = 0;
-            }
-
             value = strtol ((char *) v, &rem, 0);
 
             if (*rem != '\0')
@@ -701,14 +701,19 @@ apteryx_get_int (const char *path, const char *key)
                 errno = -ERANGE;
                 value = -1;
             }
-
-            if (apteryx_debug && errno == -ERANGE)
-            {
-                DEBUG ("Cannot represent value as int: %s\n", v);
-            }
-
+            
             free (v);
         }
+        else
+        {
+            errno = -ERANGE;
+        }
+
+        if (apteryx_debug && errno == -ERANGE)
+        {
+            DEBUG ("Cannot represent value as int: %s\n", v);
+        }
+
         free (full_path);
     }
     return value;

--- a/apteryx.c
+++ b/apteryx.c
@@ -677,7 +677,8 @@ apteryx_get_int (const char *path, const char *key)
     char *full_path;
     size_t len;
     char *v = NULL;
-    int value = -1;
+    char *rem = NULL;
+    int32_t value = -1;
 
     /* Create full path */
     if (key)
@@ -688,7 +689,24 @@ apteryx_get_int (const char *path, const char *key)
     {
         if ((v = apteryx_get (full_path)))
         {
-            value = atoi ((char *) v);
+            if (apteryx_debug)
+            {
+                errno = 0;
+            }
+
+            value = strtol ((char *) v, &rem, 0);
+
+            if (*rem != '\0')
+            {
+                errno = -ERANGE;
+                value = -1;
+            }
+
+            if (apteryx_debug && errno == -ERANGE)
+            {
+                DEBUG ("Cannot represent value as int: %s\n", v);
+            }
+
             free (v);
         }
         free (full_path);

--- a/apteryx.h
+++ b/apteryx.h
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <errno.h>
 #include <glib.h>
 
 /** Apteryx configuration

--- a/apteryx.h
+++ b/apteryx.h
@@ -164,7 +164,10 @@ bool apteryx_set_int (const char *path, const char *key, int32_t value);
 char *apteryx_get (const char *path);
 /** Helper to retrieve the value using an extended path based on the specified key */
 char *apteryx_get_string (const char *path, const char *key);
-/** Helper to retrieve a simple integer from an extended path */
+/** 
+ * Helper to retrieve a simple integer from an extended path 
+ * @return -1 if the value cannot be represented as an int (and set errno to -ERANGE)
+ */
 int32_t apteryx_get_int (const char *path, const char *key);
 
 /**

--- a/test.c
+++ b/test.c
@@ -523,6 +523,27 @@ test_set_get_int ()
 
     CU_ASSERT ((v = apteryx_get_int (path, "count")) == value);
 
+    /* test correct behavior with strings */
+    char *strvalue = "illegal";
+
+    CU_ASSERT (apteryx_set_string (path, "count", strvalue));
+
+    v = 0;
+
+    CU_ASSERT((v = apteryx_get_int (path, "count")) == -1);
+
+    CU_ASSERT((errno == -ERANGE));
+
+    strvalue = "123illegal";
+
+    CU_ASSERT (apteryx_set_string (path, "count", strvalue));
+
+    v = 0;
+
+    CU_ASSERT((v = apteryx_get_int (path, "count")) == -1);
+
+    CU_ASSERT((errno == -ERANGE));
+
     CU_ASSERT (apteryx_set_string (path, "count", NULL));
     CU_ASSERT (assert_apteryx_empty ());
 }


### PR DESCRIPTION
and set errno accordingly.

apteryx_get_int on a field set as:
123, returns 123
123abc, returns -1 (errno == -ERANGE)
abc, returns -1 (errno == -ERANGE)

A client error checking a field with -1 as a legal value is responsible
for setting errno to 0 before making the apteryx call.