### PR TITLE
search: Improve search speed

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -1086,7 +1086,7 @@ handle_search_response (const Apteryx__SearchResult *result, void *closure_data)
         for (i = 0; i < result->n_paths; i++)
         {
             DEBUG ("    = %s\n", result->paths[i]);
-            data->paths = g_list_append (data->paths,
+            data->paths = g_list_prepend (data->paths,
                               (gpointer) strdup (result->paths[i]));
         }
         data->done = true;

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -111,7 +111,7 @@ handle_search_response (const Apteryx__SearchResult *result, void *closure_data)
     {
         for (i = 0; i < result->n_paths; i++)
         {
-            data->paths = g_list_append (data->paths,
+            data->paths = g_list_prepend (data->paths,
                               (gpointer) g_strdup (result->paths[i]));
         }
         data->done = true;
@@ -154,7 +154,7 @@ handle_traverse_response (const Apteryx__TraverseResult *result, void *closure_d
             pv->path = strdup (pvread->path + slen);
             pv->value = strdup (pvread->value);
             DEBUG ("  %s = %s\n", pv->path, pv->value);
-            data->paths = g_list_append (data->paths, pv);
+            data->paths = g_list_prepend (data->paths, pv);
         }
         data->done = true;
     }
@@ -997,7 +997,7 @@ search_path (const char *path)
                 if ((ptr = strchr (&provider_path[len ? len : len+1], '/')) != 0)
                     *ptr = '\0';
                 if (!g_list_find_custom (results, provider_path, (GCompareFunc) strcmp))
-                    results = g_list_append (results, provider_path);
+                    results = g_list_prepend (results, provider_path);
                 else
                     g_free (provider_path);
             }
@@ -1344,7 +1344,7 @@ apteryx__prune (Apteryx__Server_Service *service,
     }
 
     /* Collect the list of deleted paths for notification */
-    paths = g_list_append(paths, g_strdup(prune->path));
+    paths = g_list_prepend(paths, g_strdup(prune->path));
     _search_paths (&paths, prune->path);
 
     /* Prune from database */

--- a/database.c
+++ b/database.c
@@ -384,10 +384,9 @@ db_search (const char *path)
     children = g_hash_table_get_values (node->children);
     for (iter = children; iter; iter = g_list_next (iter))
     {
-        char *value = NULL;
-        struct database_node *node = iter->data;
-        db_node_to_path (node, &value);
-        values = g_list_append (values, value);
+        values = g_list_prepend (values,
+                                 g_strdup_printf("%s%s", strlen(path) > 0 ? path : "/",
+                                                 ((struct database_node*)iter->data)->key));
     }
     g_list_free (children);
     pthread_rwlock_unlock (&db_lock);


### PR DESCRIPTION
The standard g_list ordering problem - appends are a LOT slower than prepend
for large lists.

Also, take a shortcut when building the paths in the database - we already know
what the leading path is, so don't need to do a node_to_path.