### PR TITLE
Add proxy mode to the apteryx schema

### DIFF
--- a/apteryx.xsd
+++ b/apteryx.xsd
@@ -31,7 +31,7 @@
 			<xs:attribute name="mode" use="optional">
 				<xs:simpleType>
 					<xs:restriction base="xs:string">
-						<xs:pattern value="(h|x|r|w|rw)"/>
+						<xs:pattern value="(p|h|x|r|w|rw)"/>
 					</xs:restriction>
 				</xs:simpleType>
 			</xs:attribute>


### PR DESCRIPTION
Used to indicate that the node links to another part of the schema,
currently only to root.