### PR TITLE
Fix a crash issue in function validate_path().

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -66,8 +66,14 @@ validate_path (const char *path, char **url)
     {
         if (url)
             *url = strdup (path);
-        path = strstr (path + 6, ":/") + 1;
-        char *tmp = strstr (*url + 6, ":/");
+        char *tmp = strstr (path + 6, ":/");
+        if (!tmp)
+        {
+            ERROR ("Invalid path (%s)!\n", path);
+            return NULL;
+        }
+        path = tmp + 1;
+        tmp = strstr (*url + 6, ":/");
         if (tmp)
         {
             tmp[0] = '\0';


### PR DESCRIPTION
Reproduce the crash:

a). Run server: 

neo@neo-matrix:~/Downloads/apteryx$ ./apteryxd -d -p apteryx2.pid -l tcp://127.0.0.1:9999
[1470729227711712:5923] RPC: New Instance (0x86ef80)
[1470729227711965:5923] RPC: tcp://127.0.0.1:9999
[1470729227712200:5923] RPC: New Socket (4:tcp://127.0.0.1:9999)
[1470729227712492:5923] RPC: New Instance (0x870b40)

b). Run client:

neo@neo-matrix:~/Downloads/allied_telesis/apteryx$ LD_LIBRARY_PATH=. ./apteryx -d -g tcp://127.0.0.1:9999:
[1470729617087358:6156] RPC: New Instance (0x15a6010)
[1470729617087483:6156] Init: Initialised
[1470729617087516:6156] GET: tcp://127.0.0.1:9999:
Segmentation fault (core dumped)

It spewed a "segment fault" error msg while getting value from an invalid path. The root cause is in function validate_path(), the return value of strstr() should be checked before assigning variable "path".

Re-run client after fixing this issue:

neo@neo-matrix:~/Downloads/apteryx$ LD_LIBRARY_PATH=. ./apteryx -d -g tcp://127.0.0.1:9999:
[1470729607023160:6153] RPC: New Instance (0x1670010)
[1470729607023222:6153] Init: Initialised
[1470729607023251:6153] GET: tcp://127.0.0.1:9999:
[1470729607023281:6153] ERROR: Invalid path (tcp://127.0.0.1:9999:)!
[1470729607023354:6153] ERROR: GET: invalid path ((null))!
apteryx: apteryx.c:626: apteryx_get: Assertion `!apteryx_debug || path' failed.
Aborted (core dumped)

The smart client reported the invalid path and program aborted at "assert (!apteryx_debug || path);"

Run without '-d':

neo@neo-matrix:~/Downloads/apteryx$ LD_LIBRARY_PATH=. ./apteryx -g tcp://127.0.0.1:9999:
Not found

It works well now :-)