### PR TITLE
Fix Alfred unit tests to not print a log message

### DIFF
--- a/alfred.c
+++ b/alfred.c
@@ -689,7 +689,7 @@ alfred_init (const char *path)
     luaL_openlibs (alfred_inst->ls);
     if (luaL_dostring (alfred_inst->ls, "require('api')") != 0)
     {
-        CRITICAL ("Lua: Failed to require('api')\n");
+        ERROR ("Lua: Failed to require('api')\n");
     }
 
     /* Add the rate_limit function to a Lua table so it can be called using Lua */


### PR DESCRIPTION
Was broken by a previous commit.