### PR TITLE
apteryx-sync: use set tree

### DIFF
--- a/apteryx.h
+++ b/apteryx.h
@@ -271,7 +271,7 @@ bool apteryx_cas_int (const char *path, const char *key, int32_t value, uint64_t
 /** Free an N-ary tree of nodes when the data need freeing (e.g. from apteryx_get_tree) */
 void apteryx_free_tree (GNode* root);
 /** Find the child of the node with the specified name */
-GNode *apteryx_find_child (GNode *parent, char *name);
+GNode *apteryx_find_child (GNode *parent, const char *name);
 /** Sort the children of a node using the supplied compare function */
 void apteryx_sort_children (GNode *parent, int (*cmp) (const char *a, const char *b));
 /** Get the full path of an Apteryx node in an N-ary tree */

--- a/syncer.c
+++ b/syncer.c
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <dirent.h>
 #include <apteryx.h>
+#include <glib-unix.h>
 #include "common.h"
 
 #define APTERYX_SYNC_PID "/var/run/apteryx-sync.pid"
@@ -14,7 +15,7 @@
 bool apteryx_debug = false;
 
 /* Run while true */
-static bool running = true;
+static GMainLoop *g_loop = NULL;
 
 typedef struct sync_partner_s
 {
@@ -26,10 +27,88 @@ typedef struct sync_partner_s
 /* keep a list of the partners we are syncing paths to */
 GList *partners = NULL;
 pthread_rwlock_t partners_lock = PTHREAD_RWLOCK_INITIALIZER;
+
+/* keep pending changes (not yet pushed to clients)... */
+static GNode *pending = NULL;
+static guint pending_timer = 0;
+static uint64_t oldest_pending = 0;
+
 /* keep a list of the paths we are syncing */
 GList *paths = NULL;
 GList *excluded_paths = NULL;
 pthread_rwlock_t paths_lock = PTHREAD_RWLOCK_INITIALIZER;
+
+static uint64_t
+now (void)
+{
+    struct timespec tms;
+    uint64_t micros = 0;
+    if (clock_gettime(CLOCK_MONOTONIC, &tms)) {
+        return 0;
+    }
+
+    micros = ((uint64_t)tms.tv_sec) * 1000000;
+    micros += tms.tv_nsec/1000;
+    return micros;
+}
+
+static bool
+flush ()
+{
+    pthread_rwlock_wrlock (&partners_lock);
+    for (GList *iter = partners; iter; iter = iter->next)
+    {
+        if (pending)
+        {
+            /* Dirty hack to do set tree without a deep copy */
+            char *next_path = NULL;
+
+            if (asprintf (&next_path, "%s:/", ((sync_partner*)iter->data)->socket) > 0)
+            {
+                free(pending->data);
+                pending->data = next_path;
+                apteryx_set_tree(pending);
+            }
+        }
+    }
+    apteryx_free_tree(pending);
+    pending = NULL;
+    pthread_rwlock_unlock (&partners_lock);
+    oldest_pending = 0;
+
+    if (pending_timer)
+        g_source_remove (pending_timer);
+    pending_timer = 0;
+
+    return false;
+}
+
+static void
+add_data_point (const char *path, const char *value)
+{
+    if (apteryx_find_child (pending, path))
+    {
+        flush ();
+    }
+    uint64_t n = now ();
+    if (pending == NULL)
+    {
+        pending = APTERYX_NODE (NULL, strdup(""));
+    }
+    APTERYX_LEAF(pending, strdup (path), value ? strdup (value) : NULL);
+    if (oldest_pending == 0)
+        oldest_pending = n;
+
+    if (!pending_timer)
+    {
+    	pending_timer = g_timeout_add (100 /*ms*/, (GSourceFunc)flush, NULL);
+    }
+    else
+    {
+    	g_source_remove(pending_timer);
+    	pending_timer = g_timeout_add (100 /*ms*/, (GSourceFunc)flush, NULL);
+    }
+}
 
 bool
 syncer_add (sync_partner *sp)
@@ -287,14 +366,8 @@ periodic_syncer_thread (void *ign)
 bool
 new_change (const char *path, const char *value)
 {
-    pthread_rwlock_rdlock (&partners_lock);
-    for (GList *iter = partners; iter; iter = iter->next)
-    {
-        sync_partner *sp = iter->data;
-        DEBUG ("Pushing NEW_CHANGE on path %s, value %s to %s\n", path, value, sp->socket);
-        apteryx_set_sp (sp, path, value);
-    }
-    pthread_rwlock_unlock (&partners_lock);
+    DEBUG ("Pushing NEW_CHANGE on path %s, value %s to cache\n", path, value);
+    add_data_point (path, value);
     return true;
 }
 
@@ -448,10 +521,11 @@ parse_config_files (const char* config_dir)
     return TRUE;
 }
 
-void
-termination_handler (void)
+static gboolean
+termination_handler (gpointer arg1)
 {
-    running = false;
+    g_main_loop_quit (g_loop);
+    return false;
 }
 
 void
@@ -504,8 +578,8 @@ main (int argc, char *argv[])
     }
 
     /* Handle SIGTERM/SIGINT/SIGPIPE gracefully */
-    signal (SIGTERM, (__sighandler_t) termination_handler);
-    signal (SIGINT, (__sighandler_t) termination_handler);
+    g_unix_signal_add (SIGINT, termination_handler, g_loop);
+    g_unix_signal_add (SIGTERM, termination_handler, g_loop);
     signal (SIGPIPE, SIG_IGN);
 
     /* Daemonize */
@@ -539,10 +613,9 @@ main (int argc, char *argv[])
     pthread_t timer;
     pthread_create (&timer, NULL, periodic_syncer_thread, NULL);
 
-    while (running)
-    {
-        pause ();
-    }
+    g_loop = g_main_loop_new (NULL, FALSE);
+    g_main_loop_run (g_loop);
+    g_main_loop_unref (g_loop);
 
     pthread_cancel (timer);
     pthread_join (timer, NULL);

--- a/test.c
+++ b/test.c
@@ -359,6 +359,36 @@ exit:
 }
 
 void
+test_perf_tcp_set_tree ()
+{
+    const char *path = TEST_TCP_URL":"TEST_PATH"/entity/zones";
+    uint64_t start;
+    int i;
+    bool res;
+
+    CU_ASSERT (apteryx_bind (TEST_TCP_URL));
+    usleep (TEST_SLEEP_TIMEOUT);
+
+    GNode *root = APTERYX_NODE(NULL, (char*)path);
+    APTERYX_LEAF (root, "private", "crash");
+
+    start = get_time_us ();
+    for (i = 0; i < TEST_ITERATIONS; i++)
+    {
+        CU_ASSERT ((res = apteryx_set_tree (root)));
+        if (!res)
+            goto exit;
+    }
+
+    printf ("%"PRIu64"us ... ", (get_time_us () - start) / TEST_ITERATIONS);
+exit:
+    g_node_destroy (root);
+    apteryx_prune(path);
+    CU_ASSERT (apteryx_unbind (TEST_TCP_URL));
+    CU_ASSERT (assert_apteryx_empty ());
+}
+
+void
 test_perf_tcp6_set ()
 {
     const char *path = TEST_TCP6_URL":"TEST_PATH"/entity/zones/private/name";
@@ -4246,6 +4276,7 @@ static CU_TestInfo tests_performance[] = {
     { "dummy", test_perf_dummy },
     { "set", test_perf_set },
     { "set(tcp)", test_perf_tcp_set },
+    { "set tree (tcp)", test_perf_tcp_set_tree },
     { "set(tcp6)", test_perf_tcp6_set },
     { "set tree 50", test_perf_set_tree },
     { "set tree 5000", test_perf_set_tree_5000 },


### PR DESCRIPTION
Hold off sending sync messages for 100ms after the last change. This
means tree sets are sent to the sync partners in one set, rather than
as a sequence of single messages.