### PR TITLE
apteryx-sync: use set tree

### DIFF
--- a/apteryx.h
+++ b/apteryx.h
@@ -271,7 +271,7 @@ bool apteryx_cas_int (const char *path, const char *key, int32_t value, uint64_t
 /** Free an N-ary tree of nodes when the data need freeing (e.g. from apteryx_get_tree) */
 void apteryx_free_tree (GNode* root);
 /** Find the child of the node with the specified name */
-GNode *apteryx_find_child (GNode *parent, char *name);
+GNode *apteryx_find_child (GNode *parent, const char *name);
 /** Sort the children of a node using the supplied compare function */
 void apteryx_sort_children (GNode *parent, int (*cmp) (const char *a, const char *b));
 /** Get the full path of an Apteryx node in an N-ary tree */

--- a/common.h
+++ b/common.h
@@ -61,6 +61,17 @@ static inline uint32_t htol32 (uint32_t v)
         printf (fmt, ## args); \
     }
 
+#define NOTICE(fmt, args...) \
+    { \
+        syslog (LOG_NOTICE, fmt, ## args); \
+        if (apteryx_debug) \
+        { \
+            fprintf (stderr, "[%"PRIu64":%d] ", get_time_us (), getpid ()); \
+            fprintf (stderr, "NOTICE: "); \
+            fprintf (stderr, fmt, ## args); \
+        } \
+    }
+
 #define ERROR(fmt, args...) \
     { \
         syslog (LOG_ERR, fmt, ## args); \

--- a/test.c
+++ b/test.c
@@ -359,6 +359,36 @@ exit:
 }
 
 void
+test_perf_tcp_set_tree ()
+{
+    const char *path = TEST_TCP_URL":"TEST_PATH"/entity/zones";
+    uint64_t start;
+    int i;
+    bool res;
+
+    CU_ASSERT (apteryx_bind (TEST_TCP_URL));
+    usleep (TEST_SLEEP_TIMEOUT);
+
+    GNode *root = APTERYX_NODE(NULL, (char*)path);
+    APTERYX_LEAF (root, "private", "crash");
+
+    start = get_time_us ();
+    for (i = 0; i < TEST_ITERATIONS; i++)
+    {
+        CU_ASSERT ((res = apteryx_set_tree (root)));
+        if (!res)
+            goto exit;
+    }
+
+    printf ("%"PRIu64"us ... ", (get_time_us () - start) / TEST_ITERATIONS);
+exit:
+    g_node_destroy (root);
+    apteryx_prune(path);
+    CU_ASSERT (apteryx_unbind (TEST_TCP_URL));
+    CU_ASSERT (assert_apteryx_empty ());
+}
+
+void
 test_perf_tcp6_set ()
 {
     const char *path = TEST_TCP6_URL":"TEST_PATH"/entity/zones/private/name";
@@ -4246,6 +4276,7 @@ static CU_TestInfo tests_performance[] = {
     { "dummy", test_perf_dummy },
     { "set", test_perf_set },
     { "set(tcp)", test_perf_tcp_set },
+    { "set tree (tcp)", test_perf_tcp_set_tree },
     { "set(tcp6)", test_perf_tcp6_set },
     { "set tree 50", test_perf_set_tree },
     { "set tree 5000", test_perf_set_tree_5000 },


### PR DESCRIPTION
Hold off sending sync messages for 100ms after the last change. This
means tree sets are sent to the sync partners in one set, rather than
as a sequence of single messages.