### PR TITLE
apteryx-sync: Don't sync a path with a timestamp of 0

### DIFF
--- a/syncer.c
+++ b/syncer.c
@@ -278,7 +278,7 @@ sync_recursive (sync_partner *sp, const char *path)
         return true;
     }
     uint64_t ts = apteryx_timestamp (path);
-    if (ts < sp->last_sync_local)
+    if (ts < sp->last_sync_local || ts == 0)
     {
         if (ts == 0)
         {


### PR DESCRIPTION
New syncers are initialised with last_sync_local set to 0. The first
time a syncer syncs, the timestamp on an apteryx path will never be
less than last_sync_local since (some uint < 0) is never true.
Provided paths have a timestamp of 0 and it is intended that they
should never be synced. To ensure this behaviour, explicitly skip any
path with a timestamp of 0.