### PR TITLE
Add option to create .run file once apteryxd is initialised

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ apteryxd = \
 		kill -TERM `cat /tmp/apteryxd.pid` && sleep 0.1; \
 	fi; \
 	rm -f /tmp/apteryxd.pid; \
-	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):./ ./apteryxd -b -p /tmp/apteryxd.pid && sleep 0.1; \
+	rm -f /tmp/apteryxd.run; \
+	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):./ ./apteryxd -b -p /tmp/apteryxd.pid -r /tmp/apteryxd.run && sleep 0.1; \
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):./ $(TEST_WRAPPER) ./$(1); \
 	kill -TERM `cat /tmp/apteryxd.pid`;
 

--- a/internal.h
+++ b/internal.h
@@ -37,8 +37,6 @@
 
 /* Default UNIX socket path */
 #define APTERYX_SERVER  "unix:///tmp/apteryx"
-/* Default PID file */
-#define APTERYX_PID     "/var/run/apteryxd.pid"
 
 /* Mode */
 typedef enum


### PR DESCRIPTION
This patch creates the file /var/run/apteryxd.run once apteryxd is
initialised. This is useful for delaying the start-up of dependent
processes such as apteryx-sync.