### PR TITLE
Close the rpc client when the proxy is deconfigured

### DIFF
--- a/config.c
+++ b/config.c
@@ -157,6 +157,20 @@ handle_proxies_set (const char *path, const char *value)
 
     DEBUG ("CFG-Proxy: %s = %s\n", guid, value);
 
+    /* If this proxy is being deleted, then close the connect to it */
+    if (!value)
+    {
+        cb = cb_find (&proxy_list, guid);
+        if (cb && cb->uri)
+        {
+            ProtobufCService *rpc_client = rpc_client_connect (proxy_rpc, cb->uri);
+            if (rpc_client)
+            {
+                rpc_client_release (proxy_rpc, rpc_client, false);
+            }
+        }
+    }
+
     cb = update_callback (&proxy_list, guid, value);
     if (cb && value)
     {

--- a/internal.h
+++ b/internal.h
@@ -149,6 +149,7 @@ extern GList *validation_list;
 extern GList *provide_list;
 extern GList *index_list;
 extern GList *proxy_list;
+extern rpc_instance proxy_rpc;
 void cb_init (void);
 cb_info_t * cb_create (GList **list, const char *guid, const char *path, uint64_t id, uint64_t callback);
 void cb_destroy (cb_info_t *cb);


### PR DESCRIPTION
If the proxy is removed because the remote node went away,
then the node comes back, the first attempt to use the connection
would fail because we kept the connection.
So close the connection when the proxy is deconfigured,
if/when it is recreated the proxy connection will be re-established
on first use.