### PR TITLE
Return empty table for search on empty path instead of nil

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -387,10 +387,6 @@ lua_apteryx_search (lua_State *L)
         return 0;
     }
     paths = apteryx_search (lua_tostring (L, 1));
-    if (!paths)
-    {
-        return 0;
-    }
     num = g_list_length (paths);
     GList *_iter = paths;
     lua_createtable (L, num, 0);


### PR DESCRIPTION
Allows the use of 'for ... pairs(apteryx_search ...'