### PR TITLE
rpc: when unproxy is called, only destroy the connection if it exists

### DIFF
--- a/config.c
+++ b/config.c
@@ -163,7 +163,7 @@ handle_proxies_set (const char *path, const char *value)
         cb = cb_find (&proxy_list, guid);
         if (cb && cb->uri)
         {
-            ProtobufCService *rpc_client = rpc_client_connect (proxy_rpc, cb->uri);
+            ProtobufCService *rpc_client = rpc_client_existing (proxy_rpc, cb->uri);
             if (rpc_client)
             {
                 rpc_client_release (proxy_rpc, rpc_client, false);

--- a/internal.h
+++ b/internal.h
@@ -135,6 +135,7 @@ void rpc_shutdown (rpc_instance rpc);
 bool rpc_server_bind (rpc_instance rpc, const char *guid, const char *url);
 bool rpc_server_release (rpc_instance rpc, const char *guid);
 int rpc_server_process (rpc_instance rpc, bool poll);
+ProtobufCService *rpc_client_existing (rpc_instance rpc, const char *url);
 ProtobufCService *rpc_client_connect (rpc_instance rpc, const char *url);
 void rpc_client_release (rpc_instance rpc, ProtobufCService *service, bool keep);
 


### PR DESCRIPTION
Previously, if the connection didn't exist it would attempt to be
created which can take a long time (20 secs) to fail.
Since this code is only here to help cleanup when the target is
known to have gone away, only cleanup if we have an active connection
to the target.