### PR TITLE
Validators now get called when doing a prune

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -1324,6 +1324,8 @@ apteryx__prune (Apteryx__Server_Service *service,
     result.result = 0;
     GList *paths = NULL, *iter;
     (void) service;
+    int validation_result = 0;
+    int validation_lock = 0;
 
     /* Check parameters */
     if (prune == NULL || prune->path == NULL)
@@ -1350,16 +1352,46 @@ apteryx__prune (Apteryx__Server_Service *service,
     paths = g_list_prepend(paths, g_strdup(prune->path));
     _search_paths (&paths, prune->path);
 
-    /* Prune from database */
-    db_delete (prune->path, UINT64_MAX);
+    /* Call validators for each pruned path to ensure the patch can be set to NULL. */
+    for (iter = paths; iter; iter = g_list_next (iter))
+    {
+        const char *path = (const char *)iter->data;
+        validation_result = validate_set (path, NULL);
+        if (validation_result != 0)
+            validation_lock++;
+        if (validation_result < 0)
+        {
+            DEBUG ("PRUNE: %s refused by validate\n", path);
+            result.result = validation_result;
+            break;
+        }
+    }
+
+    /* Only do the prune if it is valid to do so. */
+    if (validation_result >= 0)
+    {
+        /* Prune from database */
+        db_delete (prune->path, UINT64_MAX);
+    }
 
     /* Return result */
     closure (&result, closure_data);
 
-    /* Call watchers for each pruned path */
-    for (iter = paths; iter; iter = g_list_next (iter))
+    if (validation_result >= 0)
     {
-        notify_watchers ((const char *)iter->data);
+        /* Call watchers for each pruned path */
+        for (iter = paths; iter; iter = g_list_next (iter))
+        {
+            notify_watchers ((const char *)iter->data);
+        }
+    }
+
+    /* Release validation lock - this is a sensitive value */
+    while (validation_lock)
+    {
+        DEBUG("PRUNE: unlocking mutex\n");
+        pthread_mutex_unlock (&validating);
+        validation_lock--;
     }
 
     g_list_free_full (paths, g_free);

--- a/test.c
+++ b/test.c
@@ -1745,6 +1745,28 @@ test_validate()
 }
 
 void
+test_validate_prune()
+{
+    _path = _value = NULL;
+    const char *path = TEST_PATH"/hostname";
+
+    CU_ASSERT (apteryx_validate (path, test_validate_callback));
+    CU_ASSERT (apteryx_set_string (path, NULL, "testing"));
+    CU_ASSERT (apteryx_prune (path));
+
+    CU_ASSERT (apteryx_set_string (path, NULL, "testing"));
+    CU_ASSERT (apteryx_validate (path, test_validate_refuse_callback));
+    CU_ASSERT (!apteryx_prune (path));
+    CU_ASSERT (errno == -EPERM);
+
+    usleep (TEST_SLEEP_TIMEOUT);
+    CU_ASSERT (apteryx_unvalidate (path, test_validate_callback));
+    CU_ASSERT (apteryx_unvalidate (path, test_validate_refuse_callback));
+    apteryx_set_string (path, NULL, NULL);
+
+}
+
+void
 test_validate_one_level()
 {
     _path = _value = NULL;
@@ -4561,6 +4583,7 @@ static CU_TestInfo tests_api_validate[] = {
     { "validate from many watches", test_validate_from_many_watches },
     { "validate set order", test_validate_ordering },
     { "validate tree order", test_validate_ordering_tree },
+    { "validate prune", test_validate_prune },
     CU_TEST_INFO_NULL,
 };
 


### PR DESCRIPTION
A prune is really a call to set everything in the path to null so the
validators should be called. If any of the validators returns an error
then don't do the prune and return the error code.