### PR TITLE
remove callback ref from assert in delete_callback

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -1533,7 +1533,7 @@ delete_callback (const char *type, const char *path, void *fn)
         cb = NULL;
     }
     pthread_mutex_unlock (&lock);
-    ASSERT (cb, return false, "CB[%"PRIu64"]: not found (%s)\n", ref, path);
+    ASSERT (cb, return false, "CB: not found (%s)\n", path);
     ref = cb->ref;
     free ((void *) cb->path);
     free (cb);


### PR DESCRIPTION
If the callback cannot be found, then there isn't a ref
for it, so we can't print it.