### PR TITLE
set: Don't prune on set to NULL

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -726,7 +726,7 @@ handle_set (rpc_message msg, bool ack)
         if (value)
             db_result = db_add_no_lock (path, (unsigned char*)value, strlen (value) + 1, ts);
         else
-            db_result = db_delete_no_lock (path, ts);
+            db_result = db_empty_no_lock (path, ts);
         if (!db_result)
         {
             DEBUG ("SET: %s = %s refused by DB\n", path, value);

--- a/internal.h
+++ b/internal.h
@@ -172,6 +172,8 @@ bool db_add_no_lock (const char *path, const unsigned char *value, size_t length
 bool db_delete (const char *path, uint64_t ts);
 void db_prune (const char *path);
 bool db_delete_no_lock (const char *path, uint64_t ts);
+bool db_empty (const char *path, uint64_t ts);
+bool db_empty_no_lock (const char *path, uint64_t ts);
 bool db_get (const char *path, unsigned char **value, size_t *length);
 GList *db_search (const char *path);
 uint64_t db_timestamp (const char *path);

--- a/test.c
+++ b/test.c
@@ -968,6 +968,32 @@ test_prune ()
 }
 
 void
+test_empty_not_prune ()
+{
+    GList *paths = NULL;
+
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/interfaces", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/interfaces/eth0", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/interfaces/eth0/state", NULL, "up"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/entities", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/entities/zones", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/entities/zones/public", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/entities/zones/private", NULL, "-"));
+    CU_ASSERT (apteryx_set (TEST_PATH"/interfaces", NULL));
+    CU_ASSERT (apteryx_set (TEST_PATH"/entities", NULL));
+
+    CU_ASSERT ((paths = apteryx_search (TEST_PATH"/interfaces/")) != NULL);
+    CU_ASSERT (g_list_length (paths) == 1);
+    g_list_free_full (paths, free);
+    CU_ASSERT ((paths = apteryx_search (TEST_PATH"/entities/zones/")) != NULL);
+    CU_ASSERT (g_list_length (paths) == 2);
+    g_list_free_full (paths, free);
+    CU_ASSERT (apteryx_prune (TEST_PATH"/interfaces"));
+    CU_ASSERT (apteryx_prune (TEST_PATH"/entities"));
+    CU_ASSERT (assert_apteryx_empty ());
+}
+
+void
 test_cas ()
 {
     const char *path = TEST_PATH"/interfaces/eth0/ifindex";
@@ -1026,7 +1052,7 @@ test_cas_int ()
     CU_ASSERT (errno == -EBUSY);
     CU_ASSERT (apteryx_get_int (path, "ifindex") == 3);
 
-    CU_ASSERT (apteryx_set (path, NULL));
+    CU_ASSERT (apteryx_prune (path));
     CU_ASSERT (assert_apteryx_empty ());
 }
 
@@ -3370,7 +3396,7 @@ test_proxy_tree_get ()
 
     CU_ASSERT (apteryx_unproxy (TEST_PATH"/remote/*", TEST_TCP_URL));
     CU_ASSERT (apteryx_unbind (TEST_TCP_URL));
-    CU_ASSERT (apteryx_set (TEST_PATH"/local", NULL));
+    CU_ASSERT (apteryx_prune (TEST_PATH"/local"));
     CU_ASSERT (assert_apteryx_empty ());
 
     apteryx_debug = false;
@@ -4586,6 +4612,7 @@ static CU_TestInfo tests_api[] = {
     { "multi threads writing to same table", test_thread_multi_write },
     { "multi processes writing to same table", test_process_multi_write },
     { "prune", test_prune },
+    { "empty set is not prune", test_empty_not_prune },
     { "cas", test_cas },
     { "cas string", test_cas_string },
     { "cas int", test_cas_int },
@@ -4796,16 +4823,16 @@ static CU_SuiteInfo suites[] = {
 #ifdef HAVE_LUA
     { "LUA", suite_init, suite_clean, tests_lua },
 #endif
-    { "Apteryx API", suite_init, suite_clean, tests_api },
-    { "Apteryx API Index", suite_init, suite_clean, tests_api_index },
-    { "Apteryx API Tree", suite_init, suite_clean, tests_api_tree },
-    { "Apteryx API Watch", suite_init, suite_clean, tests_api_watch },
-    { "Apteryx API Validate", suite_init, suite_clean, tests_api_validate },
-    { "Apteryx API Provide", suite_init, suite_clean, tests_api_provide },
-    { "Apteryx API Proxy", suite_init, suite_clean, tests_api_proxy },
-    { "Apteryx API Find", suite_init, suite_clean, tests_find },
-    { "Apteryx API Single Threaded", suite_init, suite_clean, tests_single_threaded },
-    { "Apteryx Performance", suite_init, suite_clean, tests_performance },
+    { "Apteryx API", suite_init, suite_clean, NULL, NULL, tests_api },
+    { "Apteryx API Index", suite_init, suite_clean, NULL, NULL, tests_api_index },
+    { "Apteryx API Tree", suite_init, suite_clean, NULL, NULL, tests_api_tree },
+    { "Apteryx API Watch", suite_init, suite_clean, NULL, NULL, tests_api_watch },
+    { "Apteryx API Validate", suite_init, suite_clean, NULL, NULL, tests_api_validate },
+    { "Apteryx API Provide", suite_init, suite_clean, NULL, NULL, tests_api_provide },
+    { "Apteryx API Proxy", suite_init, suite_clean, NULL, NULL, tests_api_proxy },
+    { "Apteryx API Find", suite_init, suite_clean, NULL, NULL, tests_find },
+    { "Apteryx API Single Threaded", suite_init, suite_clean, NULL, NULL, tests_single_threaded },
+    { "Apteryx Performance", suite_init, suite_clean, NULL, NULL, tests_performance },
     CU_SUITE_INFO_NULL,
 };
 


### PR DESCRIPTION
If set to NULL removes all children, then there is no way to
unset a value from a node without recreating all the children.
Make set to NULL only remove the value from the node and
leave the node around if it has children.
The timestamp on the node will be updated because it's value
has changed.