### PR TITLE
Remove duplicate entries in search

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -827,6 +827,7 @@ static GList *
 search_path (const char *path)
 {
     GList *results = NULL;
+    GList *iter;
 
     /* Proxy first */
     results = proxy_search (path);
@@ -846,7 +847,13 @@ search_path (const char *path)
             GList *providers = NULL;
             providers = config_search_providers (path);
             DEBUG (" got %d entries from providers...\n", g_list_length (providers));
-            results = g_list_concat (results, providers);
+            for (iter = providers; iter; iter = iter->next)
+            {
+                char *p = (char*)iter->data;
+                if (!g_list_find_custom(results, p, (GCompareFunc)strcmp))
+                    results = g_list_prepend (results, strdup(p));
+            }
+            g_list_free_full(providers, free);
         }
     }
     return results;

--- a/test.c
+++ b/test.c
@@ -2300,11 +2300,19 @@ test_provide_search ()
     GList *paths = NULL;
 
     CU_ASSERT (apteryx_provide (path, test_provide_callback_up));
+    CU_ASSERT (apteryx_set (TEST_PATH"/interfaces/eth0/size", "huge"));
     CU_ASSERT ((paths = apteryx_search (TEST_PATH"/interfaces/eth0/")) != NULL);
-    CU_ASSERT (g_list_length (paths) == 1);
+    CU_ASSERT (g_list_length (paths) == 2);
     CU_ASSERT (g_list_find_custom (paths, path, (GCompareFunc) strcmp) != NULL);
     g_list_free_full (paths, free);
+
+    CU_ASSERT ((paths = apteryx_search (TEST_PATH"/interfaces/")) != NULL);
+    CU_ASSERT (g_list_length (paths) == 1);
+    CU_ASSERT (g_list_find_custom (paths, TEST_PATH"/interfaces/eth0", (GCompareFunc) strcmp) != NULL);
+    g_list_free_full (paths, free);
+
     apteryx_unprovide (path, test_provide_callback_up);
+    CU_ASSERT (apteryx_set (TEST_PATH"/interfaces/eth0/size",NULL));
     CU_ASSERT (assert_apteryx_empty ());
 }
 


### PR DESCRIPTION
It was possible to get a duplicate search entry if paths
existed in both the database and as a provided field.