### PR TITLE
Fix apteryx_prune("/")

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -1317,8 +1317,25 @@ handle_prune (rpc_message msg)
     /* Only do the prune if it is valid to do so. */
     if (validation_result >= 0)
     {
-        /* Prune from database */
-        db_prune (path);
+        /* Prune from database - but protect /apteryx */
+        if (strcmp (path, "/") == 0)
+        {
+            GList *nodes = db_search (path);
+            GList *iter = NULL;
+            for (iter = nodes; iter; iter = iter->next)
+            {
+                const char *child_path = (const char*)iter->data;
+                if (strcmp(child_path, "/apteryx"))
+                {
+                    db_prune (child_path);
+                }
+            }
+            g_list_free_full (nodes, free);
+        }
+        else
+        {
+            db_prune (path);
+        }
     }
 
     if (validation_result >= 0)

--- a/test.c
+++ b/test.c
@@ -969,6 +969,27 @@ test_prune ()
 }
 
 void
+test_prune_root ()
+{
+    GList *paths = NULL;
+
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/interfaces", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/interfaces/eth0", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/interfaces/eth0/state", NULL, "up"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/entities", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/entities/zones", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/entities/zones/public", NULL, "-"));
+    CU_ASSERT (apteryx_set_string (TEST_PATH"/entities/zones/private", NULL, "-"));
+    CU_ASSERT (apteryx_prune ("/"));
+
+    CU_ASSERT ((paths = apteryx_search (TEST_PATH"/interfaces/")) == NULL);
+    CU_ASSERT ((paths = apteryx_search (TEST_PATH"/entities/zones/")) == NULL);
+
+    g_list_free_full (paths, free);
+    CU_ASSERT (assert_apteryx_empty ());
+}
+
+void
 test_cas ()
 {
     const char *path = TEST_PATH"/interfaces/eth0/ifindex";
@@ -4910,6 +4931,7 @@ static CU_TestInfo tests_api[] = {
     { "multi threads writing to same table", test_thread_multi_write },
     { "multi processes writing to same table", test_process_multi_write },
     { "prune", test_prune },
+    { "prune root", test_prune_root },
     { "cas", test_cas },
     { "cas string", test_cas_string },
     { "cas int", test_cas_int },


### PR DESCRIPTION
Pruning the root node is not supported - this removes the /apteryx
path that apteryxd requires for correct operation. This change
implements what is meant by apteryx_prune("/") - that is, remove
all user settings.