### PR TITLE
Make db_prune thread-safe

### DIFF
--- a/database.c
+++ b/database.c
@@ -288,6 +288,8 @@ db_evaporate (struct database_node *node)
 void
 db_prune (const char *path)
 {
+    pthread_rwlock_wrlock (&db_lock);
+
     struct database_node *node =
         (struct database_node *) hashtree_path_to_node (root, path);
 
@@ -296,6 +298,8 @@ db_prune (const char *path)
         db_purge (node);
         db_evaporate (node);
     }
+
+    pthread_rwlock_unlock (&db_lock);
 }
 
 void

--- a/test.c
+++ b/test.c
@@ -989,6 +989,87 @@ test_prune_root ()
     CU_ASSERT (assert_apteryx_empty ());
 }
 
+static bool set_prune_running = false;
+static GNode *prune_thread_safe_tree_root = NULL;
+
+static int
+_set_prune_thread (void *data)
+{
+    while (set_prune_running)
+    {
+        CU_ASSERT (apteryx_set_string (TEST_PATH"/platform/pluggables", "port1.1.1", "11"));
+        CU_ASSERT (apteryx_prune (TEST_PATH"/platform/pluggables/port1.1.1"));
+    }
+
+    return 0;
+}
+
+static int
+_search_thread (void *data)
+{
+    int i;
+    int iterations = * (int *) data;
+    GList *paths;
+
+    for (i=0; i<iterations; i++)
+    {
+        paths = apteryx_search(TEST_PATH"/platform/pluggables/");
+        g_list_free_full (paths, free);
+    }
+
+    return 0;
+}
+
+void
+test_prune_thread_safe ()
+{
+    char *name, *value;
+    int num_boards = 8;
+    int num_ports = 12;
+    int board, port, i;
+    int num_search_threads = 10;
+    int num_search_iterations = 100;
+    pthread_t set_prune_thread;
+    pthread_t search_threads[num_search_threads];
+
+    /* Generate test tree */
+    CU_ASSERT ((name = strdup (TEST_PATH"/platform/pluggables")) != NULL);
+    CU_ASSERT ((prune_thread_safe_tree_root = APTERYX_NODE (NULL, name)) != NULL);
+    for (board=1; board<=num_boards; board++)
+    {
+        for (port=1; port<=num_ports; port++)
+        {
+            name = value = NULL;
+            CU_ASSERT (asprintf (&name, "port1.%d.%d", board, port));
+            CU_ASSERT (asprintf (&value, "%d%d", board, port));
+            APTERYX_LEAF (prune_thread_safe_tree_root, name, value);
+        }
+    }
+    CU_ASSERT (apteryx_set_tree (prune_thread_safe_tree_root));
+
+    /* Start set_prune and search threads */
+    set_prune_running = true;
+    pthread_create (&set_prune_thread, NULL, (void *) &_set_prune_thread, NULL);
+    for (i=0; i<num_search_threads; i++)
+    {
+        pthread_create (&search_threads[i], NULL, (void *) &_search_thread, (void *) &num_search_iterations);
+    }
+
+    /* Collect set_prune and search threads */
+    for (i=0; i<num_search_threads; i++)
+    {
+        pthread_join (search_threads[i], NULL);
+    }
+    set_prune_running = false;
+    pthread_join (set_prune_thread, NULL);
+
+    /* Clean up */
+    usleep (TEST_SLEEP_TIMEOUT);
+    apteryx_prune (TEST_PATH"/platform/pluggables");
+    apteryx_free_tree (prune_thread_safe_tree_root);
+    CU_ASSERT (assert_apteryx_empty ());
+}
+
 void
 test_cas ()
 {
@@ -4932,6 +5013,7 @@ static CU_TestInfo tests_api[] = {
     { "multi processes writing to same table", test_process_multi_write },
     { "prune", test_prune },
     { "prune root", test_prune_root },
+    { "prune thread-safe", test_prune_thread_safe},
     { "cas", test_cas },
     { "cas string", test_cas_string },
     { "cas int", test_cas_int },


### PR DESCRIPTION
It was possible for db_search to access a node as it was being pruned.
This could result in undefined behaviour and/or segfault.