### PR TITLE
Add get helpers with default values

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -693,6 +693,18 @@ apteryx_get_string (const char *path, const char *key)
     return str;
 }
 
+char *
+apteryx_get_string_default (const char *path, const char *key, char *deflt)
+{
+    char *value = NULL;
+    value = apteryx_get_string (path, key);
+    if (!value)
+    {
+        return deflt;
+    }
+    return value;
+}
+
 int32_t
 apteryx_get_int (const char *path, const char *key)
 {
@@ -738,6 +750,24 @@ apteryx_get_int (const char *path, const char *key)
 
         free (full_path);
     }
+    return value;
+}
+
+int32_t
+apteryx_get_int_default (const char *path, const char *key, int32_t deflt)
+{
+    int32_t value;
+    int errno_old;
+
+    errno_old = errno;
+    errno = 0;
+    value = apteryx_get_int (path, key);
+    if (value == -1 && errno == -ERANGE)
+    {
+        value = deflt;
+    }
+
+    errno = errno_old;
     return value;
 }
 

--- a/apteryx.c
+++ b/apteryx.c
@@ -694,13 +694,13 @@ apteryx_get_string (const char *path, const char *key)
 }
 
 char *
-apteryx_get_string_default (const char *path, const char *key, char *deflt)
+apteryx_get_string_default (const char *path, const char *key, const char *deflt)
 {
     char *value = NULL;
     value = apteryx_get_string (path, key);
     if (!value)
     {
-        return deflt;
+        value = strdup (deflt);
     }
     return value;
 }

--- a/apteryx.h
+++ b/apteryx.h
@@ -198,11 +198,13 @@ bool apteryx_set_int (const char *path, const char *key, int32_t value);
 char *apteryx_get (const char *path);
 /** Helper to retrieve the value using an extended path based on the specified key */
 char *apteryx_get_string (const char *path, const char *key);
+char *apteryx_get_string_default (const char *path, const char *key, char *deflt);
 /**
  * Helper to retrieve a simple integer from an extended path
  * @return -1 if the value cannot be represented as an int (and set errno to -ERANGE)
  */
 int32_t apteryx_get_int (const char *path, const char *key);
+int32_t apteryx_get_int_default (const char *path, const char *key, int32_t deflt);
 
 /**
  * Check if a path has a value in Apteryx

--- a/apteryx.h
+++ b/apteryx.h
@@ -198,7 +198,7 @@ bool apteryx_set_int (const char *path, const char *key, int32_t value);
 char *apteryx_get (const char *path);
 /** Helper to retrieve the value using an extended path based on the specified key */
 char *apteryx_get_string (const char *path, const char *key);
-char *apteryx_get_string_default (const char *path, const char *key, char *deflt);
+char *apteryx_get_string_default (const char *path, const char *key, const char *deflt);
 /**
  * Helper to retrieve a simple integer from an extended path
  * @return -1 if the value cannot be represented as an int (and set errno to -ERANGE)


### PR DESCRIPTION
It is sometimes useful to be able to specify a value which should be
returned if no valid value was found. This commit adds wrapper functions
which allow just that.