### PR TITLE
Shutdown remaining users on Apteryx library exit/unload

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -1693,3 +1693,14 @@ apteryx_timestamp (const char *path)
     DEBUG ("    = %"PRIu64"\n", value);
     return value;
 }
+
+/**
+ * When the Apteryx library is unloaded or a process is exited, this will be called
+ * automatically and will shut down all remaining users.
+ */
+__attribute__ ((destructor)) void
+apteryx_unload (void)
+{
+    DEBUG ("UNLOAD: Shutting down remaining users\n");
+    apteryx_shutdown_force ();
+}


### PR DESCRIPTION
This will prevent any file descriptor leakage due to processes not
correctly calling apteryx_shutdown once for each apteryx_init.

Signed-off-by: Luuk Paulussen <luuk.paulussen@alliedtelesis.co.nz>