### PR TITLE
Prevent blocking in single-threaded mode.

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
When we queue more than the default pipe size
number of watch events in single-threaded mode.