### PR TITLE
Add -lpthread to apteryx client library pkgconfig file.

### DIFF
--- a/apteryx.pc
+++ b/apteryx.pc
@@ -8,4 +8,4 @@ Description: The Apteryx client library
 Version: 2.0.0
 Requires: glib-2.0
 Cflags: -I${includedir}
-Libs: -L${libdir} -lapteryx
+Libs: -L${libdir} -lapteryx -lpthread


### PR DESCRIPTION
As the library links against pthread, this should be part of the pkgconfig
libs line.

Signed-off-by: Luuk Paulussen <luuk.paulussen@alliedtelesis.co.nz>