### PR TITLE
Fixed seg fault during apteryxd shutdown

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -1627,8 +1627,6 @@ exit:
     }
 
     /* Cleanup callbacks */
-    config_shutdown ();
-    db_shutdown ();
     if (proxy_rpc)
     {
         rpc_shutdown (proxy_rpc);
@@ -1638,6 +1636,9 @@ exit:
         rpc_server_release (rpc, url);
         rpc_shutdown (rpc);
     }
+
+    db_shutdown ();
+    config_shutdown ();
 
     /* Remove the pid file */
     if (background && pid_file)


### PR DESCRIPTION
As the main thread in apteryxd is cleaning up another
thread tries to access the callback glist's which
generates a segfault. This is fixed here by allowing
other clean up functions using the callback glists
to run first before we cleanup the lists themselves.