### PR TITLE
Allow apteryx_query to return subtrees similar to apteryx_get_tree

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -1144,6 +1144,7 @@ apteryx_query (GNode *root)
     char *old_root_name = NULL;
     char *value = NULL;
     GNode *rroot = NULL;
+    int slen;
 
     ASSERT ((ref_count > 0), return NULL, "QUERY: Not initialised\n");
     ASSERT (root, return NULL, "QUERY: Invalid parameters\n");
@@ -1167,6 +1168,7 @@ apteryx_query (GNode *root)
         assert (!apteryx_debug || strstr (path, "//") == NULL);
         return NULL;
     }
+    slen = strlen (path);
 
     /* IPC */
     rpc_client = rpc_client_connect (rpc, url);
@@ -1205,7 +1207,7 @@ apteryx_query (GNode *root)
         {
             value = rpc_msg_decode_string (&msg);
             DEBUG ("  %s = %s\n", path, value);
-            apteryx_path_to_node (rroot, path, value);
+            apteryx_path_to_node (rroot, path + slen, value);
             path = rpc_msg_decode_string (&msg);
         }
     }

--- a/test.c
+++ b/test.c
@@ -2872,10 +2872,45 @@ test_query_basic ()
     APTERYX_NODE (iroot, strdup ("ifname"));
     rroot = apteryx_query (root);
     CU_ASSERT (g_node_n_nodes (rroot, G_TRAVERSE_LEAVES) == 2);
+    CU_ASSERT (g_node_n_nodes (rroot, G_TRAVERSE_ALL) == 10);
 
     apteryx_free_tree (rroot);
     apteryx_free_tree (root);
     g_free (path);
+
+    apteryx_prune (TEST_PATH);
+}
+
+void
+test_query_subtree_root ()
+{
+    GNode *root = NULL;
+    GNode *rroot = NULL;
+
+    root = APTERYX_NODE (NULL, TEST_PATH"/routing/ipv4/rib/1");
+    APTERYX_LEAF (root, "proto", "static");
+    APTERYX_LEAF (root, "ifname", "eth0");
+    APTERYX_LEAF (root, "prefix", "10.0.0.0/8");
+    CU_ASSERT (apteryx_set_tree (root));
+    g_node_destroy (root);
+
+    root = APTERYX_NODE (NULL, TEST_PATH"/routing/ipv4/rib/2");
+    APTERYX_LEAF (root, "proto", "static");
+    APTERYX_LEAF (root, "ifname", "eth1");
+    APTERYX_LEAF (root, "prefix", "172.16.0.0/16");
+    CU_ASSERT (apteryx_set_tree (root));
+    g_node_destroy (root);
+    root = NULL;
+
+    root = g_node_new (strdup (TEST_PATH"/routing/ipv4/rib/1"));
+    APTERYX_NODE (root, strdup ("proto"));
+    APTERYX_NODE (root, strdup ("ifname"));
+    rroot = apteryx_query (root);
+    CU_ASSERT (g_node_n_nodes (rroot, G_TRAVERSE_LEAVES) == 2);
+    CU_ASSERT (g_node_n_nodes (rroot, G_TRAVERSE_ALL) == 5);
+
+    apteryx_free_tree (rroot);
+    apteryx_free_tree (root);
 
     apteryx_prune (TEST_PATH);
 }
@@ -5252,6 +5287,7 @@ static CU_TestInfo tests_api_tree[] = {
     { "get tree indexed/provided", test_get_tree_indexed_provided },
     { "get tree provided", test_get_tree_provided },
     { "query basic", test_query_basic},
+    { "query subtree root", test_query_subtree_root},
     { "query one star", test_query_one_star},
     { "query one star traverse", test_query_one_star_traverse},
     { "query multi star traverse", test_query_multi_star_traverse},


### PR DESCRIPTION
If the root node in a query request is a longer path, rather than just
"/", use the full path as the root of the response tree, rather than
creating nodes for all of the path elements.

Previously it was possible to create a query like
 Root:/test/routing/ipv4/rib/1
 -> proto
 -> ifname
but the response would come back as
 Root:/test/routing/ipv4/rib/1 # in theory this should be "/"
 -> test
 --> routing
 ---> ipv4
 ----> rib
 -----> 1
 ------> proto = value
 ------> ifname = value

Now it will come back as:
 Root:/test/routing/ipv4/rib/1
 -> proto = value
 -> ifname = value

The existing behaviour still works the same if the query is passed in
with a "/" as the root.