### PR TITLE
Update timestamps in DB on successful refresh.

### DIFF
--- a/database.c
+++ b/database.c
@@ -82,6 +82,30 @@ db_timestamp (const char *path)
     return timestamp;
 }
 
+static void
+_db_update_timestamps (struct database_node *node, uint64_t ts)
+{
+    node->timestamp = ts;
+    GList *children = hashtree_children_get (&node->hashtree_node);
+    for (GList *iter = children; iter; iter = g_list_next (iter))
+    {
+        _db_update_timestamps ((struct database_node *) iter->data, ts);
+    }
+}
+
+void
+db_update_timestamps (const char *path, uint64_t ts)
+{
+    pthread_rwlock_rdlock (&db_lock);
+    struct hashtree_node *node = hashtree_path_to_node (root, path);
+    if (node)
+    {
+        _db_update_timestamps ((struct database_node *) node, ts);
+    }
+    pthread_rwlock_unlock (&db_lock);
+    return;
+}
+
 bool
 db_add_no_lock (const char *path, const unsigned char *value, size_t length, uint64_t ts)
 {

--- a/internal.h
+++ b/internal.h
@@ -183,6 +183,7 @@ bool db_delete_no_lock (const char *path, uint64_t ts);
 bool db_get (const char *path, unsigned char **value, size_t *length);
 GList *db_search (const char *path);
 uint64_t db_timestamp (const char *path);
+void db_update_timestamps (const char *path, uint64_t ts);
 
 /* RPC API */
 #define RPC_TIMEOUT_US 1000000


### PR DESCRIPTION
The refresher might have decided the data in the DB
is up to date and does not need refreshing but we
do not want to try and refresh it again until the
timeout has expired.