### PR TITLE
Don't treat ECONNABORTED as an error

### DIFF
--- a/rpc_socket.c
+++ b/rpc_socket.c
@@ -29,7 +29,7 @@ recv_data (int fd, void *data, size_t len)
             {
                 continue;
             }
-            else if (errno == ECONNRESET)
+            else if (errno == ECONNRESET || errno == ECONNABORTED)
             {
                 DEBUG ("RPC[%i]: Recv data: %s\n", fd, strerror (errno));
             }


### PR DESCRIPTION
This error is returned if the connection was forcefully aborted by
another process running on the machine (i.e. some form of network
manager). Simply treat this error the same as if the other end of
the connection decides to reset the connection.