### PR TITLE
Speed up apteryx_get_tree operations

### DIFF
--- a/config.c
+++ b/config.c
@@ -332,6 +332,24 @@ config_get_validators (const char *path)
     return cb_match (validation_list, path);
 }
 
+bool
+config_tree_has_refreshers (const char *path)
+{
+    return cb_exists (refresh_list, path);
+}
+
+bool
+config_tree_has_providers (const char *path)
+{
+    return cb_exists (provide_list, path);
+}
+
+bool
+config_tree_has_indexers (const char *path)
+{
+    return cb_exists (index_list, path);
+}
+
 void
 config_init (void)
 {

--- a/internal.h
+++ b/internal.h
@@ -244,6 +244,10 @@ GList *config_get_proxies (const char *path);
 GList *config_get_watchers (const char *path);
 GList *config_get_validators (const char *path);
 
+bool config_tree_has_refreshers (const char *path);
+bool config_tree_has_providers (const char *path);
+bool config_tree_has_indexers (const char *path);
+
 /* Callbacks to clients */
 struct callback_node *cb_init (void);
 cb_info_t *cb_create (struct callback_node *list, const char *guid, const char *path,
@@ -258,7 +262,8 @@ void cb_release (cb_info_t *cb);
 #define CB_MATCH_WILD_PATH  (1<<4)
 #define CB_PATH_MATCH_PART  (1<<5)
 GList *cb_match (struct callback_node *list, const char *path);
-/* Returns a list of paths */
+bool cb_exists (struct callback_node *list, const char *path);
+/* Returns a list of paths which have callbacks further down. */
 GList *cb_search (struct callback_node *node, const char *path);
 void cb_shutdown (struct callback_node *root);
 


### PR DESCRIPTION
A couple of changes to speed up apteryx_get_tree:

1) Hunt for refreshers directly, rather than searching for and running
indexers and providers before looking for refreshers. Only hunt for
refreshers / indexers / providers when we know there are some left down
this branch of the tree.

2) When traversing down the paths keep track of which types of callbacks
are present, and quit looking for callbacks that don't exist down a
branch. This is acheived with a new cb_exists function that returns true
if this path has a callback of the given type below it somewhere.