### PR TITLE
Process WATCH_WITH_ACK in the same thread as WATCH

### DIFF
--- a/rpc.c
+++ b/rpc.c
@@ -131,6 +131,7 @@ request_cb (rpc_socket sock, rpc_id id, void *buffer, size_t len)
 {
     rpc_instance rpc;
     struct rpc_work_s *work;
+    bool watch = false;
 
     DEBUG ("RPC[%d]: received %zd bytes\n", sock->sock, len);
 
@@ -163,6 +164,15 @@ request_cb (rpc_socket sock, rpc_id id, void *buffer, size_t len)
         work->responded = true;
     }
 
+    /* Both variants of watch callbacks need to be processed on the same thread -
+     * this is the single thread servicing the "slow_workers" pool.
+     */
+    if (*(unsigned char*)buffer == MODE_WATCH ||
+        *(unsigned char*)buffer == MODE_WATCH_WITH_ACK)
+    {
+        watch = true;
+    }
+
     /* Check if in polling mode first */
     if (rpc->queue)
     {
@@ -174,7 +184,7 @@ request_cb (rpc_socket sock, rpc_id id, void *buffer, size_t len)
         }
     }
     /* Callbacks from local Apteryx threads */
-    else if (rpc->workers && work->responded)
+    else if (rpc->slow_workers && watch)
         g_thread_pool_push (rpc->slow_workers, work, NULL);
     else if (rpc->workers)
         g_thread_pool_push (rpc->workers, work, NULL);
@@ -219,6 +229,7 @@ rpc_init (int timeout, rpc_msg_handler handler)
     rpc->clients = g_hash_table_new (g_str_hash, g_str_equal);
     rpc->workers = g_thread_pool_new ((GFunc)worker_func, (gpointer)&rpc->worker_sigmask,
                                       8, FALSE, NULL);
+    /* slow_workers handles the watch callbacks and must be served by a single thread. */
     rpc->slow_workers = g_thread_pool_new ((GFunc)worker_func,
                                            (gpointer)&rpc->worker_sigmask,
                                            1, FALSE, NULL);

--- a/test.c
+++ b/test.c
@@ -1874,6 +1874,58 @@ test_watch_myself_blocked ()
     CU_ASSERT (assert_apteryx_empty ());
 }
 
+
+static pthread_t watch_thread_id = -1;
+static bool
+test_watch_callback_thread_info (const char *path, const char *value)
+{
+    if (_path)
+        free (_path);
+    if (_value)
+        free (_value);
+
+    usleep(TEST_SLEEP_TIMEOUT / 100);
+
+    if (watch_thread_id == -1)
+        watch_thread_id = pthread_self ();
+    else
+        CU_ASSERT (pthread_self() == watch_thread_id);
+
+    _path = strdup (path);
+    if (value)
+        _value = strdup (value);
+    else
+        _value = NULL;
+    _cb_count++;
+    return true;
+}
+
+
+void
+test_watch_ack_thread ()
+{
+    const char *path = TEST_PATH"/entity/zones/private/state";
+    _cb_count = 0;
+    watch_thread_id = -1;
+    CU_ASSERT (apteryx_watch (path, test_watch_callback_thread_info));
+    apteryx_set (path, "1");
+    apteryx_set_wait (path, "2");
+
+    /* By the time the apteryx_set_wait finishes we have to have cleared the
+     * backlog of watch callbacks.
+     */
+    CU_ASSERT (_cb_count == 2);
+    apteryx_set (path, "3");
+
+    /* The test sleep timeout should be long enough for the callback to be
+     * called.
+     */
+    usleep (TEST_SLEEP_TIMEOUT);
+    CU_ASSERT (_cb_count == 3);
+    CU_ASSERT (apteryx_unwatch (path, test_watch_callback_thread_info));
+    apteryx_prune (TEST_PATH);
+}
+
 static bool
 test_perf_watch_callback (const char *path, const char *value)
 {
@@ -6034,6 +6086,7 @@ static CU_TestInfo tests_api_watch[] = {
     { "watch order", test_watch_order },
     { "watch rpc restart", test_watch_rpc_restart },
     { "watch myself blocked", test_watch_myself_blocked },
+    { "watch and watch_with_ack in same thread", test_watch_ack_thread },
     CU_TEST_INFO_NULL,
 };
 


### PR DESCRIPTION
WATCH_WITH_ACK needs to be processed in the same thread as the WATCH callbacks to avoid client applications needing to provide a thread safe watch callback.