### PR TITLE
Align watch_with_ack with watch callbacks

### DIFF
--- a/callbacks.c
+++ b/callbacks.c
@@ -747,6 +747,7 @@ test_cb_exist_locking ()
     }
     test_running = false;
     pthread_join (thrasher, NULL);
+    cb_shutdown (test_list);
 }
 
 CU_TestInfo tests_callbacks[] = {


### PR DESCRIPTION
The callbacks generated by apteryx_set_wait were being processed by a
different thread than those generated by apteryx_set - this was
unintentional and can lead to the client process needing to be thread
safe when it usually would not be required.