### PR TITLE
Delete correct callback when paths and fn are the same

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -277,7 +277,7 @@ void cb_shutdown (struct callback_node *root);
 
 /* Callbacks to users */
 bool add_callback (const char *type, const char *path, void *fn, bool value, void *data, uint32_t flags);
-bool delete_callback (const char *type, const char *path, void *fn);
+bool delete_callback (const char *type, const char *path, void *fn, void *data);
 
 /* Tests */
 void run_unit_tests (const char *filter);

--- a/lua.c
+++ b/lua.c
@@ -496,8 +496,9 @@ lua_apteryx_unindex (lua_State *L)
     luaL_checktype(L, 1, LUA_TSTRING);
     luaL_checktype(L, 2, LUA_TFUNCTION);
     const char *path = lua_tostring (L, 1);
+    size_t ref = ref_callback (L, 2);
 
-    if (!delete_callback (APTERYX_INDEXERS_PATH, path, (void *)lua_do_index))
+    if (!delete_callback (APTERYX_INDEXERS_PATH, path, (void *)lua_do_index, (void *) ref))
     {
         luaL_error (L, "Failed to unregister callback\n");
         lua_pushboolean (L, false);
@@ -552,8 +553,9 @@ lua_apteryx_unwatch (lua_State *L)
     luaL_checktype(L, 1, LUA_TSTRING);
     luaL_checktype(L, 2, LUA_TFUNCTION);
     const char *path = lua_tostring (L, 1);
+    size_t ref = ref_callback (L, 2);
 
-    if (!delete_callback (APTERYX_WATCHERS_PATH, path, (void *)lua_do_watch))
+    if (!delete_callback (APTERYX_WATCHERS_PATH, path, (void *)lua_do_watch, (void *) ref))
     {
         luaL_error (L, "Failed to unregister callback\n");
         lua_pushboolean (L, false);
@@ -613,8 +615,9 @@ lua_apteryx_unrefresh (lua_State *L)
     luaL_checktype(L, 1, LUA_TSTRING);
     luaL_checktype(L, 2, LUA_TFUNCTION);
     const char *path = lua_tostring (L, 1);
+    size_t ref = ref_callback (L, 2);
 
-    if (!delete_callback (APTERYX_REFRESHERS_PATH, path, (void *)lua_do_refresh))
+    if (!delete_callback (APTERYX_REFRESHERS_PATH, path, (void *)lua_do_refresh, (void *) ref))
     {
         luaL_error (L, "Failed to unregister callback\n");
         lua_pushboolean (L, false);
@@ -675,8 +678,9 @@ lua_apteryx_unvalidate (lua_State *L)
     luaL_checktype(L, 1, LUA_TSTRING);
     luaL_checktype(L, 2, LUA_TFUNCTION);
     const char *path = lua_tostring (L, 1);
+    size_t ref = ref_callback (L, 2);
 
-    if (!delete_callback (APTERYX_VALIDATORS_PATH, path, (void *)lua_do_validate))
+    if (!delete_callback (APTERYX_VALIDATORS_PATH, path, (void *)lua_do_validate, (void *) ref))
     {
         luaL_error (L, "Failed to unregister callback\n");
         lua_pushboolean (L, false);
@@ -736,8 +740,9 @@ lua_apteryx_unprovide (lua_State *L)
     luaL_checktype(L, 1, LUA_TSTRING);
     luaL_checktype(L, 2, LUA_TFUNCTION);
     const char *path = lua_tostring (L, 1);
+    size_t ref = ref_callback (L, 2);
 
-    if (!delete_callback (APTERYX_PROVIDERS_PATH, path, (void *)lua_do_provide))
+    if (!delete_callback (APTERYX_PROVIDERS_PATH, path, (void *)lua_do_provide, (void *) ref))
     {
         luaL_error (L, "Failed to unregister callback\n");
         lua_pushboolean (L, false);

--- a/test.c
+++ b/test.c
@@ -6009,6 +6009,64 @@ test_lua_basic_watch (void)
     CU_ASSERT (assert_apteryx_empty ());
 }
 
+void
+test_lua_multiple_watchers ()
+{
+        CU_ASSERT (_run_lua (
+            "apteryx = require('apteryx')                                 \n"
+            "local v1 = nil                                               \n"
+            "local v2 = nil                                               \n"
+            "local v3 = nil                                               \n"
+            "function test_watch1 (path, value)                             "
+            "    assert (path == '"TEST_PATH"/watch')                       "
+            "    v1 = value                                                 "
+            "end                                                          \n"
+            "function test_watch2 (path, value)                             "
+            "    assert (path == '"TEST_PATH"/watch')                       "
+            "    v2 = value                                                 "
+            "end                                                          \n"
+            "function test_watch3 (path, value)                             "
+            "    assert (path == '"TEST_PATH"/watch')                       "
+            "    v3 = value                                                 "
+            "end                                                          \n"
+            "apteryx.watch('"TEST_PATH"/watch', test_watch1)              \n"
+            "apteryx.process()                                            \n"
+            "apteryx.watch('"TEST_PATH"/watch', test_watch2)              \n"
+            "apteryx.process()                                            \n"
+            "apteryx.watch('"TEST_PATH"/watch', test_watch3)              \n"
+            "apteryx.process()                                            \n"
+            "apteryx.set('"TEST_PATH"/watch', 'me')                       \n"
+            "apteryx.process()                                            \n"
+            "apteryx.process()                                            \n"
+            "apteryx.process()                                            \n"
+            "assert(v1 == 'me')                                           \n"
+            "assert(v2 == 'me')                                           \n"
+            "assert(v3 == 'me')                                           \n"
+            "apteryx.unwatch('"TEST_PATH"/watch', test_watch1)            \n"
+            "apteryx.process()                                            \n"
+            "apteryx.set('"TEST_PATH"/watch', 'too')                      \n"
+            "apteryx.process()                                            \n"
+            "apteryx.process()                                            \n"
+            "apteryx.process()                                            \n"
+            "assert(v1 == 'me')                                           \n"
+            "assert(v2 == 'too')                                          \n"
+            "assert(v3 == 'too')                                          \n"
+            "apteryx.unwatch('"TEST_PATH"/watch', test_watch3)            \n"
+            "apteryx.process()                                            \n"
+            "apteryx.set('"TEST_PATH"/watch', 'again')                    \n"
+            "apteryx.process()                                            \n"
+            "apteryx.process()                                            \n"
+            "apteryx.process()                                            \n"
+            "assert(v1 == 'me')                                           \n"
+            "assert(v2 == 'again')                                        \n"
+            "assert(v3 == 'too')                                          \n"
+            "apteryx.unwatch('"TEST_PATH"/watch', test_watch2)            \n"
+            "apteryx.set('"TEST_PATH"/watch')                             \n"
+            "apteryx.process(false)                                       \n"
+    ));
+    CU_ASSERT (assert_apteryx_empty ());
+}
+
 static int
 test_lua_refresh_thread (void *data)
 {
@@ -6568,6 +6626,7 @@ CU_TestInfo tests_lua[] = {
     { "lua basic query", test_lua_basic_query},
     { "lua basic timestamp", test_lua_basic_timestamp },
     { "lua basic watch", test_lua_basic_watch },
+    { "lua multiple watchers", test_lua_multiple_watchers },
     { "lua basic refresh", test_lua_basic_refresh },
     { "lua basic provide", test_lua_basic_provide },
     { "lua basic index", test_lua_basic_index },


### PR DESCRIPTION
If data has been provided then we need to compare that
as well. Currently used by LUA where the C fn is the
same, but the data (ref to the lua fn) are different.

Protect next_ref with the existing lock in case there
are two callbacks created at the same time.