### PR TITLE
Makefile: don't link against libcunit unnecessarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ endif
 endif
 ifneq ($(HAVE_TESTS),no)
 EXTRA_CSRC += test.c
-EXTRA_CFLAGS += -DTEST
-EXTRA_LDFLAGS += -lcunit
+apteryx_CFLAGS += -DTEST
+apteryx_LDFLAGS += -lcunit
 endif
 
 all: libapteryx.so apteryx apteryxd
@@ -60,7 +60,7 @@ apteryxd: apteryxd.c hashtree.c database.c rpc.o rpc_transport.o rpc_socket.o co
 
 apteryx: apteryxc.c hashtree.c database.c callbacks.c libapteryx.so $(EXTRA_CSRC)
 	@echo "Building $@"
-	$(Q)$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $^ -L. -lapteryx $(EXTRA_LDFLAGS)
+	$(Q)$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(apteryx_CFLAGS) -o $@ $^ -L. -lapteryx $(EXTRA_LDFLAGS) $(apteryx_LDFLAGS)
 
 apteryxd = \
 	if test -e /tmp/apteryxd.pid; then \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 ifneq ($(HAVE_TESTS),no)
 EXTRA_CSRC += test.c
 EXTRA_CFLAGS += -DTEST
-apteryx_LDFLAGS += -lcunit
+EXTRA_LDFLAGS += -lcunit
 endif
 
 all: libapteryx.so apteryx apteryxd
@@ -60,7 +60,7 @@ apteryxd: apteryxd.c hashtree.c database.c rpc.o rpc_transport.o rpc_socket.o co
 
 apteryx: apteryxc.c hashtree.c database.c callbacks.c libapteryx.so $(EXTRA_CSRC)
 	@echo "Building $@"
-	$(Q)$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $^ -L. -lapteryx $(EXTRA_LDFLAGS) $(apteryx_LDFLAGS)
+	$(Q)$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $^ -L. -lapteryx $(EXTRA_LDFLAGS)
 
 apteryxd = \
 	if test -e /tmp/apteryxd.pid; then \


### PR DESCRIPTION
Need to have apteryx specific CFLAGS and LDFLAGS. This could be make cleaner with autotools but this will do for now.