### PR TITLE
apteryx_timestamp: support refreshers / providers

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -428,19 +428,20 @@ calculate_timestamp (void)
     return micros;
 }
 
-static void
-call_refreshers (const char *path)
+static bool
+call_refreshers (const char *path, bool dry_run)
 {
     GList *refreshers = NULL;
     GList *iter = NULL;
     uint64_t timestamp;
     uint64_t now;
     uint64_t timeout = 0;
+    bool refresh_due = false;
 
     /* Retrieve a list of refreshers for this path */
     refreshers = config_get_refreshers (path);
     if (!refreshers)
-        return;
+        return false;
 
     /* Get the time of the request */
     now = calculate_timestamp ();
@@ -491,51 +492,59 @@ call_refreshers (const char *path)
                 path, refresher->path, refresher->id, refresher->ref, refresher->uri);
 
         /* IPC */
-        rpc_client = rpc_client_connect (rpc, refresher->uri);
-        if (!rpc_client)
+        if (!dry_run)
         {
-            /* Throw away the no good validator */
-            ERROR ("Invalid REFRESH CB %s (0x%"PRIx64",0x%"PRIx64")\n",
-                   refresher->path, refresher->id, refresher->ref);
-            cb_disable (refresher);
-            INC_COUNTER (counters.refreshed_no_handler);
-            goto unlock;
-        }
-        rpc_msg_encode_uint8 (&msg, MODE_REFRESH);
-        rpc_msg_encode_uint64 (&msg, refresher->ref);
-        rpc_msg_encode_string (&msg, path);
-        start = get_time_us ();
-        res = rpc_msg_send (rpc_client, &msg);
-        duration = get_time_us () - start;
-        if (!res)
-        {
-            INC_COUNTER (counters.refreshed_timeout);
-            ERROR ("Failed to notify refresher for path \"%s\"\n", (char *) path);
-            rpc_client_release (rpc, rpc_client, false);
+            rpc_client = rpc_client_connect (rpc, refresher->uri);
+            if (!rpc_client)
+            {
+                /* Throw away the no good validator */
+                ERROR ("Invalid REFRESH CB %s (0x%"PRIx64",0x%"PRIx64")\n",
+                    refresher->path, refresher->id, refresher->ref);
+                cb_disable (refresher);
+                INC_COUNTER (counters.refreshed_no_handler);
+                goto unlock;
+            }
+            rpc_msg_encode_uint8 (&msg, MODE_REFRESH);
+            rpc_msg_encode_uint64 (&msg, refresher->ref);
+            rpc_msg_encode_string (&msg, path);
+            start = get_time_us ();
+            res = rpc_msg_send (rpc_client, &msg);
+            duration = get_time_us () - start;
+            if (!res)
+            {
+                INC_COUNTER (counters.refreshed_timeout);
+                ERROR ("Failed to notify refresher for path \"%s\"\n", (char *) path);
+                rpc_client_release (rpc, rpc_client, false);
+            }
+            else
+            {
+                rpc_client_release (rpc, rpc_client, true);
+                timeout = rpc_msg_decode_uint64 (&msg);
+                DEBUG ("REFRESH again in %"PRIu64"us\n", timeout);
+                if (refresher->timeout == 0 || timeout < refresher->timeout)
+                    refresher->timeout = timeout;
+                /* Make sure the DB has up to date timestamps */
+                db_update_timestamps (path, now);
+            }
+            rpc_msg_reset (&msg);
+
+            INC_COUNTER (counters.refreshed);
+            if (!GET_COUNTER (refresher->min) || duration < GET_COUNTER (refresher->min))
+                SET_COUNTER (refresher->min, duration);
+            if (duration > GET_COUNTER (refresher->max))
+                SET_COUNTER (refresher->max, duration);
+            ADD_COUNTER (refresher->total, duration);
+            INC_COUNTER (refresher->count);
         }
         else
         {
-            rpc_client_release (rpc, rpc_client, true);
-            timeout = rpc_msg_decode_uint64 (&msg);
-            DEBUG ("REFRESH again in %"PRIu64"us\n", timeout);
-            if (refresher->timeout == 0 || timeout < refresher->timeout)
-                refresher->timeout = timeout;
-            /* Make sure the DB has up to date timestamps */
-            db_update_timestamps (path, now);
+            refresh_due = true;
         }
-        rpc_msg_reset (&msg);
-
-        INC_COUNTER (counters.refreshed);
-        if (!GET_COUNTER (refresher->min) || duration < GET_COUNTER (refresher->min))
-            SET_COUNTER (refresher->min, duration);
-        if (duration > GET_COUNTER (refresher->max))
-            SET_COUNTER (refresher->max, duration);
-        ADD_COUNTER (refresher->total, duration);
-        INC_COUNTER (refresher->count);
     unlock:
         pthread_mutex_unlock (&refresher->lock);
     }
     g_list_free_full (refreshers, (GDestroyNotify) cb_release);
+    return refresh_due;
 }
 
 static char *
@@ -1186,7 +1195,7 @@ get_value (const char *path)
     if ((value = proxy_get (path)) == NULL)
     {
         /* Call refreshers */
-        call_refreshers (path);
+        call_refreshers (path, false);
 
         /* Database second */
         if (!db_get (path, (unsigned char**)&value, &vsize))
@@ -1253,7 +1262,7 @@ search_path (const char *path)
         else
         {
             /* Call refreshers */
-            call_refreshers (path);
+            call_refreshers (path, false);
 
             /* Search database next */
             results = db_search (path);
@@ -1475,7 +1484,7 @@ refreshers_traverse (const char *top_path, char cb_lookup)
     GList *iter, *paths = NULL;
     gchar *needle = g_strdup_printf("%s/", top_path);
 
-    call_refreshers (needle);
+    call_refreshers (needle, false);
 
     if (!config_tree_has_refreshers (top_path))
     {
@@ -1501,7 +1510,7 @@ refreshers_traverse (const char *top_path, char cb_lookup)
     }
     paths = g_list_concat (db_search (needle), paths);
 
-    cb_lookup = _update_path_callbacks (needle, cb_lookup);
+    cb_lookup = _update_path_callbacks (top_path, cb_lookup);
     free (needle);
 
     for (iter = paths; iter; iter = g_list_next (iter))
@@ -1518,7 +1527,7 @@ collect_provided_paths(const char *_path, GNode *root)
     gchar *path = _path ? g_strdup(_path) : apteryx_node_path(root);
     GList *result = NULL;
     GList *provided_paths = NULL;
-
+    gchar *needle = g_strdup_printf("%s/", path);
     if (!config_tree_has_providers(path))
     {
         goto exit;
@@ -1532,7 +1541,7 @@ collect_provided_paths(const char *_path, GNode *root)
         g_list_free_full (search_result, (GDestroyNotify) cb_release);
     }
 
-    gchar *needle = g_strdup_printf("%s/", path);
+
     index_get(needle, &result);
     result = g_list_concat(result, config_search_providers(needle));
     result = g_list_concat(result, config_search_indexers(needle));
@@ -1956,7 +1965,15 @@ handle_timestamp (rpc_message msg)
     if ((value = proxy_timestamp (path)) == 0)
     {
         /* Lookup value */
-        value = db_timestamp (path);
+        if (config_tree_has_providers (path) ||
+            call_refreshers (path, true))
+        {
+            value = calculate_timestamp ();
+        }
+        else
+        {
+            value = db_timestamp (path);
+        }
     }
 
     /* Send result */

--- a/callbacks.c
+++ b/callbacks.c
@@ -403,8 +403,8 @@ _cb_exists (struct callback_node *node, const char *path)
         return true;
     }
 
-    /* Terminating condition */
-    if (strlen (path) == 0 || !strchr (path + 1, '/'))
+    /* Got only one node left, check here for directory and terminal wildcard */
+    if (path[0] != '\0' && !strchr (path + 1, '/'))
     {
         if (node->directory)
         {
@@ -417,19 +417,24 @@ _cb_exists (struct callback_node *node, const char *path)
         {
             return true;
         }
+    }
 
-        if (!hashtree_empty (&node->hashtree_node))
+    /* Down to the final possible node */
+    if (path[0] == '\0')
+    {
+        /* We got to the end of the path, but it has something else below it. */
+        if(!hashtree_empty (&node->hashtree_node))
         {
             return true;
         }
 
-        node = (struct callback_node *) hashtree_path_to_node (&node->hashtree_node, path);
-        if (node && node->exact)
+        /* Got an exact match */
+        if (node->exact || node->directory)
         {
             return true;
         }
 
-        return false;
+	    return false;
     }
 
     char *tmp = strdup (path + 1);


### PR DESCRIPTION
apteryx_timestamp returns a value that can be used to detect changes in
the database. When we have providers, a read of that value will always
be required, with refreshers this is required some period after the
previous update.

apteryx_timestamp will now return the current time when a provided value
timestamp is requested, and when an expired refreshed value is
requested. This value will be less than the subsequent data read, as is
required by the interface.