### PR TITLE
apteryx_node_path: Handle root nodes better

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -963,8 +963,13 @@ _node_to_path (GNode *node, char **buf)
         _node_to_path (node->parent, buf);
 
     char *tmp = NULL;
+
+    char *key = node ? node->data : "";
+    if (key[0] == '/' && key[1] == '\0')
+        key++;
+
     if (asprintf (&tmp, "%s%s%s", *buf ? : "",
-            node ? (char*)node->data : "/",
+            key,
             end ? "" : "/") >= 0)
     {
         free (*buf);

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -843,8 +843,13 @@ _node_to_path (GNode *node, char **buf)
         _node_to_path (node->parent, buf);
 
     char *tmp = NULL;
+
+    char *key = node ? node->data : "";
+    if (key[0] == '/' && key[1] == '\0')
+        key++;
+
     if (asprintf (&tmp, "%s%s%s", *buf ? : "",
-            node ? (char*)node->data : "/",
+            key,
             end ? "" : "/") >= 0)
     {
         free (*buf);

--- a/test.c
+++ b/test.c
@@ -6070,6 +6070,33 @@ test_path_to_node ()
     node = root->children;
     CU_ASSERT (node && strcmp(APTERYX_NAME(node), "system-name") == 0);
     g_node_destroy (root);
+
+    root = APTERYX_NODE (NULL, "/");
+    apteryx_path_to_node (root, "/system/system-name", "awplus");
+    node = root->children;
+    path = apteryx_node_path(node);
+    CU_ASSERT (path && strcmp (path, "/system") == 0);
+    g_free (path);
+    CU_ASSERT (node && strcmp(APTERYX_NAME(node), "system") == 0);
+    node = node->children;
+    path = apteryx_node_path(node);
+    CU_ASSERT (path && strcmp (path, "/system/system-name") == 0);
+    g_free (path);
+    CU_ASSERT (node && strcmp(APTERYX_NAME(node), "system-name") == 0);
+    node = node->children;
+    CU_ASSERT (node && strcmp(APTERYX_NAME(node), "awplus") == 0);
+    g_node_destroy (root);
+
+    root = APTERYX_NODE (NULL, "/system");
+    apteryx_path_to_node (root, "/system/system-name", "awplus");
+    node = root->children;
+    path = apteryx_node_path(node);
+    CU_ASSERT (path && strcmp (path, "/system/system-name") == 0);
+    g_free (path);
+    CU_ASSERT (node && strcmp(APTERYX_NAME(node), "system-name") == 0);
+    node = node->children;
+    CU_ASSERT (node && strcmp(APTERYX_NAME(node), "awplus") == 0);
+    g_node_destroy (root);
 }
 
 static bool


### PR DESCRIPTION
When creating the path for a node, we were sometimes adding an extra /
precending the path, if the tree was created with a root node with a
path of "/".