### PR TITLE
Make sure RPC is tidied up when shared library is unloaded

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -34,6 +34,9 @@
 #include "apteryx.h"
 #include <glib.h>
 
+/* Flag the destructor so things get tidied up when the shared library is unloaded */
+bool apteryx_shutdown_force (void) __attribute__((destructor));
+
 /* Configuration */
 bool apteryx_debug = false;                      /* Debug enabled */
 static const char *default_url = APTERYX_SERVER; /* Default path to Apteryx database */


### PR DESCRIPTION
When a LUA script uses the Apteryx LUA module it is possible for RPC messages to continue to arrive after the shared library has been unloaded as LUA doesn't know how to shutdown the module. This can lead to segment violations in LUA. A similar situation is possible via apteryx-xml.

By flagging apteryx_shutdown_force as a destructor the RPC will be correctly shutdown when the shared library is unloaded.