### PR TITLE
Avoid shutting down the parents RPC after a fork

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -459,6 +459,7 @@ apteryx_shutdown (void)
 bool
 apteryx_shutdown_force (void)
 {
+    DEBUG ("SHUTDOWN: (Forced)\n");
     while (ref_count > 0)
         apteryx_shutdown ();
     return true;

--- a/rpc.c
+++ b/rpc.c
@@ -26,6 +26,7 @@
 struct rpc_instance_s {
     /* Protect the instance */
     pthread_mutex_t lock;
+    int pid;
 
     /* General settings */
     int timeout;
@@ -223,6 +224,7 @@ rpc_init (int timeout, rpc_msg_handler handler)
 
     /* Create a new RPC instance */
     pthread_mutex_init (&rpc->lock, NULL);
+    rpc->pid = getpid ();
     pthread_sigmask (SIG_SETMASK, NULL, &rpc->worker_sigmask);
     rpc->timeout = timeout;
     rpc->gc_time = get_time_us ();
@@ -264,6 +266,13 @@ rpc_shutdown (rpc_instance rpc)
     int i;
 
     assert (rpc);
+
+    /* Check this instance belongs to us */
+    if (rpc->pid != getpid())
+    {
+        ERROR ("RPC: Attempt to shutdown instance (%p) that belongs to pid %d\n", rpc, rpc->pid);
+        return;
+    }
 
     DEBUG ("RPC: Shutdown Instance (%p)\n", rpc);
 


### PR DESCRIPTION
Because we use PID in the name of our unix file descriptors fork really does not work well.