### PR TITLE
Traverse all children on a query

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -1894,7 +1894,7 @@ collect_provided_paths_query(GNode *query)
     return matches;
 }
 
-static gboolean _refresh_paths (GNode *node, gpointer data)
+static void _refresh_paths (GNode *node, gpointer data)
 {
     char *path = NULL;
 
@@ -1906,7 +1906,7 @@ static gboolean _refresh_paths (GNode *node, gpointer data)
         _node_to_path (node->parent, &path);
         refreshers_traverse (path, cb_all);
         free (path);
-        return FALSE;
+        return;
     }
 
     /* Handle direct matches */
@@ -1916,12 +1916,12 @@ static gboolean _refresh_paths (GNode *node, gpointer data)
         _node_to_path (node, &path);
         call_refreshers (path, false);
         free (path);
-        return FALSE;
+        return;
     }
 
     /* Traverse children */
-    g_node_traverse (node->children, G_PRE_ORDER, G_TRAVERSE_NON_LEAFS, 1, _refresh_paths, NULL);
-    return FALSE;
+    g_node_children_foreach (node, G_TRAVERSE_NON_LEAFS, _refresh_paths, NULL);
+    return;
 }
 
 static bool
@@ -1967,7 +1967,7 @@ handle_query (rpc_message msg)
     free (root_path);
 
     /* Traverse the tree calling refreshers */
-    g_node_traverse (query_head, G_PRE_ORDER, G_TRAVERSE_NON_LEAFS, 1, _refresh_paths, NULL);
+    g_node_children_foreach (query_head, G_TRAVERSE_NON_LEAFS, _refresh_paths, NULL);
 
     /* Query the database */
     root = db_query (query_head);

--- a/test.c
+++ b/test.c
@@ -4859,6 +4859,35 @@ test_query_refreshed_multi_wildcard()
 }
 
 void
+test_query_refreshed_multi_branches()
+{
+    const char *path = TEST_PATH"/devices/*";
+    GNode *root , *node, *rroot;
+
+    _cb_count = 0;
+    _cb_timeout = 5000;
+    apteryx_refresh (path, refresh_state_callback);
+
+    root = g_node_new (g_strdup (TEST_PATH));
+    node = APTERYX_NODE (root, g_strdup ("cars"));
+    node = APTERYX_NODE (node, g_strdup ("*"));
+    node = APTERYX_NODE (root, g_strdup ("devices"));
+    node = APTERYX_NODE (node, g_strdup ("*"));
+    node = APTERYX_NODE (node, g_strdup ("interfaces"));
+    node = APTERYX_NODE (node, g_strdup ("*"));
+    node = APTERYX_NODE (node, g_strdup ("state"));
+    rroot = apteryx_query (root);
+    CU_ASSERT (rroot && g_node_n_nodes (rroot, G_TRAVERSE_LEAVES) == 1);
+    apteryx_free_tree (rroot);
+    apteryx_free_tree (root);
+    CU_ASSERT (_cb_count == 1);
+
+    apteryx_unrefresh (path, refresh_state_callback);
+    apteryx_set (TEST_PATH"/devices/dut/interfaces/eth1/state", NULL);
+    apteryx_prune (TEST_PATH);
+}
+
+void
 test_query_refreshed_once()
 {
     const char *path = TEST_PATH"/devices/dut/interfaces/eth1/state";
@@ -8101,6 +8130,7 @@ static CU_TestInfo tests_api_tree[] = {
     { "query refreshed simple", test_query_refreshed_simple},
     { "query refreshed mid wildcard", test_query_refreshed_mid_wildcard},
     { "query refreshed multi wildcard", test_query_refreshed_multi_wildcard},
+    { "query refreshed multi branches", test_query_refreshed_multi_branches},
     { "query refreshed once", test_query_refreshed_once},
     { "query not refreshed one path", test_query_not_refreshed_one_path},
     { "query not refreshed two paths", test_query_not_refreshed_two_paths},


### PR DESCRIPTION
Only the first path of a multi branch query were being hit due to g_node_traverse being called with the first child. Use g_node_children_foreach instead.