### PR TITLE
Fix a crash in apteryx_find_child

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -896,7 +896,7 @@ apteryx_find_child (GNode *parent, const char *name)
 
     for (node = g_node_first_child (parent); node; node = node->next)
     {
-        if (strcmp (APTERYX_NAME (node), name) == 0)
+        if (g_strcmp0 (APTERYX_NAME (node), name) == 0)
         {
             return node;
         }


### PR DESCRIPTION
If a node is passed in with node->data set as NULL, then the strcmp function crashes with a SIGSEGV fault. This is fixed by using the more robust g_strcmp0