### PR TITLE
Ignore empty nodes when appending from a query

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -1096,8 +1096,8 @@ _apteryx_print_tree (GNode *node, FILE *fp, int depth)
     if (node)
     {
         const char *name = APTERYX_NAME (node);
-        if (depth == 0 && name[0] == '/')
-            fprintf (fp, "%s\n", name + 1);
+        if (depth == 0)
+            fprintf (fp, "%s\n", name);
         else
             fprintf (fp, "%*s%s\n", depth * 2, " ", name);
         for (GNode *child = node->children; child; child = child->next)
@@ -1307,6 +1307,8 @@ q2n_append_path (GNode *root, const char *path)
 {
     char **nodes = g_strsplit (path, "/", -1);
     char **node = nodes;
+    if (*node && (*node)[0] == '\0')
+        node++;
     while (*node)
     {
         GNode *existing = apteryx_find_child (root, *node);

--- a/test.c
+++ b/test.c
@@ -3941,6 +3941,38 @@ test_query2node_invalid ()
 }
 
 void
+test_query2node_empty_root_no_slash ()
+{
+    char *expect = "/\n"
+                   "  test\n"
+                   "    system\n"
+                   "      time\n";
+    GNode *root = g_node_new (g_strdup ("/"));
+    CU_ASSERT (apteryx_query_to_node (root, "test/system/time"));
+    char *buffer = dump_apteryx_tree (root);
+    CU_ASSERT (g_strcmp0 (buffer, expect) == 0)
+    free (buffer);
+    apteryx_free_tree (root);
+}
+
+void
+test_query2node_empty_root_slash ()
+{
+    char *expect = "/\n"
+                   "  test\n"
+                   "    system\n"
+                   "      time\n";
+    GNode *root = g_node_new (g_strdup ("/"));
+    CU_ASSERT (apteryx_query_to_node (root, "/test/system/time"));
+    char *buffer = dump_apteryx_tree (root);
+    printf("\nE:\n%s", expect);
+    printf("\nB:\n%s", buffer);
+    CU_ASSERT (g_strcmp0 (buffer, expect) == 0)
+    free (buffer);
+    apteryx_free_tree (root);
+}
+
+void
 test_query2node_single_field ()
 {
     GNode *root = g_node_new (g_strdup (TEST_PATH"/system"));
@@ -4077,7 +4109,7 @@ test_query2node_two_path_merge_two_nodes ()
 void
 test_query2node_deep_nodes ()
 {
-    char *expect = "test\n"
+    char *expect = "/test\n"
                    "  h\n"
                    "    a\n"
                    "      t\n"
@@ -4099,7 +4131,7 @@ test_query2node_deep_nodes ()
 void
 test_query2node_deep_paths ()
 {
-    char *expect = "test\n"
+    char *expect = "/test\n"
                    "  h\n"
                    "    a\n"
                    "      j\n"
@@ -8263,6 +8295,8 @@ static CU_TestInfo tests_api_tree[] = {
     { "get tree provider writes", test_get_tree_provider_write },
     { "get tree thrashing" , test_get_tree_while_thrashing },
     { "query2node invalid" , test_query2node_invalid },
+    { "query2node empty root no slash", test_query2node_empty_root_no_slash },
+    { "query2node empty root slash", test_query2node_empty_root_slash },
     { "query2node single field", test_query2node_single_field },
     { "query2node double field", test_query2node_double_field },
     { "query2node single field path", test_query2node_single_field_path },


### PR DESCRIPTION
This can happen due to the split by "/" and if the path starts with a "/".
Make apteryx_print_tree print the actual tree to help debug these issues.