### PR TITLE
Add support for more control of set watch callbacks

### DIFF
--- a/apteryx.h
+++ b/apteryx.h
@@ -76,6 +76,13 @@
 #define APTERYX_COUNTERS                         "/apteryx/counters"
 #define APTERYX_STATISTICS                       "/apteryx/statistics"
 
+typedef enum {
+    FLAG_SET_NONE = 0,
+    FLAG_SET_WATCH = 1,
+    FLAG_SET_ACK = 2,
+    FLAG_SET_WATCH_NOT_SELF = 4,
+} set_flags;
+
 /** Initialise this instance of the Apteryx library.
  * @param debug verbose debug to stdout
  * @return true on success
@@ -172,6 +179,17 @@ bool apteryx_set_full (const char *path, const char *value, uint64_t ts,
 bool apteryx_set_tree_full (GNode *root, uint64_t ts, bool wait_for_completion);
 
 /**
+ * Set a tree of multiple values in Apteryx, with full options
+ * @param root pointer to the N-ary tree of nodes.
+ * @param ts monotonic timestamp to be compared to the paths last change time
+ * @param id is the pid of the process to not send a watch callback to
+ * @param flags allow the control of acking and watch callbacks
+ * @return true on a successful set
+ * @return false if the path is invalid
+ */
+bool apteryx_set_tree_with_flags (GNode* root, uint64_t ts, uint64_t id, set_flags flags);
+
+/**
  * Set a path/value in Apteryx
  * @param path path to the value to set
  * @param value value to set at the specified path
@@ -193,6 +211,13 @@ bool apteryx_set_tree_full (GNode *root, uint64_t ts, bool wait_for_completion);
 bool apteryx_set_string (const char *path, const char *key, const char *value);
 /** Helper to store a simple int at an extended path */
 bool apteryx_set_int (const char *path, const char *key, int32_t value);
+
+/** Helper to extend the path with the specified key */
+bool apteryx_set_string_with_flags (const char *path, const char *key, const char *value,
+                                    uint64_t id, set_flags flags);
+/** Helper to store a simple int at an extended path */
+bool apteryx_set_int_with_flags (const char *path, const char *key, int32_t value,
+                                 uint64_t id, set_flags flags);
 
 /**
  * Get a path/value from Apteryx


### PR DESCRIPTION
If multiple YANG models configure the same data in a system then a complex set of watches are required to keep the various processes implementing the models synchronized. As an example of this consider the implementation of the IETF and Openconfig interface models. If both implementations watch the data of the other model (needed to keep the configuration data synchronized), then if one model changes its data, the other model will receive a watch callback and update its data to match. This causes the first model to receive a watch callback about the change in the second model. This easily leads to a storm of watch callbacks.

This change allows more options of how watch callbacks are generated when data is set in database. Two new options are now possible when setting data:-
1) Set data in the database but do not call any watch callbacks. 2) Set data in the database but block any callbacks to a specific watcher.