### PR TITLE
Lock the slow work thread context when modifying delayed work

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -245,18 +245,13 @@ dw_add (uint64_t ref, void *fn, GNode *root, void *data, guint timeout_ms)
         dw = NULL;
     }
 
-    /* If we found a match lets merge in the new data */
+    /* If we found a match lets merge in the new data and restart the timer */
     if (dw)
     {
-        dw_list = g_list_remove (dw_list, dw);
-        rpc_del_callback (rpc, dw->handle);
-        root = apteryx_merge_tree (dw->root, root);
-        g_free (dw);
-        dw = NULL;
+        dw->root = apteryx_merge_tree (dw->root, root);
+        rpc_restart_callback (rpc, dw->handle, timeout_ms);
     }
-
-    /* Create a new timer for the requested timeout */
-    if (!dw)
+    else
     {
         dw = (struct delayed_watch *) g_malloc0 (sizeof (struct delayed_watch));
         dw->ref = ref;

--- a/internal.h
+++ b/internal.h
@@ -247,7 +247,8 @@ rpc_client rpc_client_existing (rpc_instance rpc, const char *url);
 rpc_client rpc_client_connect (rpc_instance rpc, const char *url);
 void rpc_client_release (rpc_instance rpc, rpc_client client, bool keep);
 gpointer rpc_add_callback (rpc_instance rpc, GSourceFunc cb, gpointer data, guint timeout_ms);
-void rpc_del_callback (rpc_instance rpc, gpointer handle);
+void rpc_restart_callback (rpc_instance rpc, gpointer handle, guint timeout_ms);
+void rpc_cancel_callback (rpc_instance rpc, gpointer handle);
 
 /* Apteryx configuration */
 void config_init (void);


### PR DESCRIPTION
When g_main_loop dispatches a timed callback it does so with the glib main context unlocked. Which means that we cannot safely restart the timer as we maybe inside the slow work callback. Use the rpc lock to protect the g_main_loop context in both the slow thread callbacks and when modifying the timer in the rpc callback functions.