### PR TITLE
Faster library unload routine

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -35,7 +35,7 @@
 #include <glib.h>
 
 /* Flag the destructor so things get tidied up when the shared library is unloaded */
-bool apteryx_shutdown_force (void) __attribute__((destructor));
+bool apteryx_halt (void) __attribute__((destructor));
 
 /* Configuration */
 bool apteryx_debug = false;                      /* Debug enabled */
@@ -515,6 +515,7 @@ apteryx_shutdown (void)
     /* Shutdown */
     DEBUG ("SHUTDOWN: Shutting down\n");
     rpc_shutdown (rpc);
+    rpc = NULL;
     bound = false;
     DEBUG ("SHUTDOWN: Shutdown\n");
     return true;
@@ -527,6 +528,14 @@ apteryx_shutdown_force (void)
     DEBUG ("SHUTDOWN: (Forced)\n");
     while (ref_count > 0)
         apteryx_shutdown ();
+    return true;
+}
+
+bool
+apteryx_halt (void)
+{
+    DEBUG ("SHUTDOWN: stopping threads prior to process exit\n");
+    rpc_halt (rpc);
     return true;
 }
 

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -2438,6 +2438,7 @@ exit:
     {
         rpc_server_release (rpc, url);
         rpc_shutdown (rpc);
+        rpc = NULL;
     }
 
     db_shutdown ();

--- a/internal.h
+++ b/internal.h
@@ -239,6 +239,7 @@ bool rpc_msg_send (rpc_client client, rpc_message msg);
 void rpc_msg_reset (rpc_message msg);
 
 rpc_instance rpc_init (int timeout, rpc_msg_handler handler);
+void rpc_halt (rpc_instance rpc);
 void rpc_shutdown (rpc_instance rpc);
 bool rpc_server_bind (rpc_instance rpc, const char *guid, const char *url);
 bool rpc_server_release (rpc_instance rpc, const char *guid);


### PR DESCRIPTION
When the library is unloaded lua requires that the threads are stopped - this is done in two parts by stopping and joining any RPC client threads, and stopping the thread pool.

The longer this process takes the more likely it is that one of the worker threads will attempt to access routines from other libraries that have unloaded and cleared their own memory. This can lead to undesired log messages and / or processes exiting with other error codes.