### PR TITLE
Use refresher timestamp rather than DB timestamps

### DIFF
--- a/apteryx.h
+++ b/apteryx.h
@@ -664,7 +664,9 @@ bool apteryx_unvalidate (const char *path, apteryx_validate_callback cb);
 
 /**
  * Callback function to be called when a library user
- * makes a get to a "refreshed" path.
+ * makes a get to a "refreshed" path. Note that the callback
+ * is not called again (for any matching path) until timeout
+ * has elapsed.
  * @param path path to the value to be refreshed
  * @return timeout in microseconds to next refresh
  */
@@ -675,10 +677,9 @@ typedef uint64_t (*apteryx_refresh_callback) (const char *path);
  * Whenever a get is performed on the given path, callback is
  * called to refresh the values of the tree.
  * examples: (using contrived usage example)
- * - apteryx_refresh ("/hw/interfaces/\*\/counters/\*", refresh_intf_tx_counters, 50);
+ * - apteryx_refresh ("/hw/interfaces/\*\/counters/\*", refresh_intf_tx_counters);
  * @param path path to the value that others will request
  * @param cb function to be called if others request the path
- * @param timeout time after refresh is requred
  * @return true on successful registration
  */
 bool apteryx_refresh (const char *path, apteryx_refresh_callback cb);

--- a/database.c
+++ b/database.c
@@ -118,32 +118,6 @@ db_memuse (const char *path)
     return memuse;
 }
 
-static void
-_db_update_timestamps (struct database_node *node, uint64_t ts)
-{
-    node->timestamp = ts;
-    GList *children = hashtree_children_get (&node->hashtree_node);
-    for (GList *iter = children; iter; iter = g_list_next (iter))
-    {
-        _db_update_timestamps ((struct database_node *) iter->data, ts);
-    }
-    g_list_free (children);
-}
-
-void
-db_update_timestamps (const char *path, uint64_t ts)
-{
-    pthread_rwlock_rdlock (&db_lock);
-    struct hashtree_node *node = hashtree_path_to_node (root, path);
-    if (node)
-    {
-        _db_update_timestamps ((struct database_node *) node, ts);
-    }
-    pthread_rwlock_unlock (&db_lock);
-    return;
-}
-
-
 /* Search for or create a node for node under db_node. node
  * may have a name with slashes in it - we will need to set up the chain
  * of database_nodes to reach the end value.

--- a/internal.h
+++ b/internal.h
@@ -121,6 +121,7 @@ typedef struct _cb_info_t
 
     struct callback_node *node;
     int refcnt;
+    uint64_t timestamp;
     uint64_t timeout;
     uint32_t count;
     uint32_t min;
@@ -198,7 +199,6 @@ GNode *db_query (GNode *query);
 GList *db_search (const char *path);
 uint64_t db_timestamp (const char *path);
 uint64_t db_memuse (const char *path);
-void db_update_timestamps (const char *path, uint64_t ts);
 
 /* RPC API */
 #define RPC_TIMEOUT_US 1000000


### PR DESCRIPTION
Ensures a refresher is only called after the users requested timeout is elapsed. Allows multiple refreshers for overlapping paths. Avoids updating database
timestamp values if they ahve not actually been
updated. Fix incorrect documentation for refresh.