### PR TITLE
Make refresh more useful

### DIFF
--- a/apteryx.h
+++ b/apteryx.h
@@ -665,9 +665,16 @@ bool apteryx_unvalidate (const char *path, apteryx_validate_callback cb);
 
 /**
  * Callback function to be called when a library user
- * makes a get to a "refreshed" path. Note that the callback
- * is not called again (for any matching path) until timeout
- * has elapsed.
+ * makes a get to a "refreshed" path. The callback
+ * is not called again for that path or any child paths
+ * until timeout has elapsed.
+ * The callback may be called again within the
+ * timeout duration if a request for a parent path
+ * matches the refresher path. e.g.
+ * REFRESH /interfaces/*
+ * GET /interfaces/eth0/state -> called
+ * GET /interfaces/eth0/state -> not called
+ * GET /interfaces/eth0 -> called
  * @param path path to the value to be refreshed
  * @return timeout in microseconds to next refresh
  */

--- a/callbacks.c
+++ b/callbacks.c
@@ -164,6 +164,10 @@ cb_free (gpointer data, void *param)
     {
         g_free ((void *) cb->uri);
     }
+    if (cb->last_path)
+    {
+        g_free ((void *) cb->last_path);
+    }
     pthread_mutex_destroy (&cb->lock);
     g_free (cb);
 }

--- a/internal.h
+++ b/internal.h
@@ -121,6 +121,7 @@ typedef struct _cb_info_t
 
     struct callback_node *node;
     int refcnt;
+    char *last_path;
     uint64_t timestamp;
     uint64_t timeout;
     uint32_t count;

--- a/test.c
+++ b/test.c
@@ -3367,6 +3367,29 @@ test_refresh_tree_no_change ()
     CU_ASSERT (assert_apteryx_empty ());
 }
 
+static uint64_t
+test_refresh_no_slash_callback (const char *path)
+{
+    _cb_count++;
+    CU_ASSERT (*(path + strlen (path) - 1) != '/');
+    return 0;
+}
+
+void
+test_refresh_no_slash ()
+{
+    const char *path = TEST_PATH"/interfaces/eth0/state";
+
+    _cb_count = 0;
+    CU_ASSERT (apteryx_refresh (path, test_refresh_no_slash_callback));
+    
+    CU_ASSERT (apteryx_get (path) == NULL);
+    CU_ASSERT (apteryx_get_tree (TEST_PATH"/interfaces/eth0") == NULL);
+    CU_ASSERT (_cb_count == 2);
+
+    apteryx_unrefresh (path, test_refresh_no_slash_callback);
+}
+
 static char*
 test_provide_callback_up (const char *path)
 {
@@ -9672,6 +9695,7 @@ static CU_TestInfo tests_api_refresh[] = {
     { "refresh path other old", test_refresh_path_other_old },
     { "refresh no change", test_refresh_no_change },
     { "refresh tree no change", test_refresh_tree_no_change },
+    { "refresh no slash", test_refresh_no_slash },
     { "refresh collision", test_refresh_collision },
     { "refresh concurrent", test_refresh_concurrent },
     { "refresh various wildcards", test_refresh_wildcards },


### PR DESCRIPTION
Originally a refresher would be called for every request if there was either an older child DB node or nothing in the DB on that path at all.

Recently a change was made to only call a refresher once in the timeout duration.

Now we record the last refreshed path so that we can refresh multiple specific paths that match the refresher path.