### PR TITLE
Support callbacks to a different namespace with socket reuse

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -455,7 +455,7 @@ apteryx_init (bool debug_enabled)
         if (have_callbacks)
         {
             /* Bind to the default uri for this client */
-            if (asprintf ((char **) &uri, APTERYX_SERVER".%"PRIu64, (uint64_t) getpid ()) <= 0
+            if (asprintf ((char **) &uri, APTERYX_CLIENT, getns (), (uint64_t) getpid ()) <= 0
                     || !rpc_server_bind (rpc, uri, uri))
             {
                 ERROR ("Failed to bind uri %s\n", uri);
@@ -2026,7 +2026,7 @@ add_callback (const char *type, const char *path, void *fn, bool value, void *da
         char * uri = NULL;
 
         /* Bind to the default uri for this client */
-        if (asprintf ((char **) &uri, APTERYX_SERVER".%"PRIu64, (uint64_t) getpid ()) <= 0
+        if (asprintf ((char **) &uri, APTERYX_CLIENT, getns (), (uint64_t) getpid ()) <= 0
                 || !rpc_server_bind (rpc, uri, uri))
         {
             ERROR ("Failed to bind uri %s\n", uri);
@@ -2040,8 +2040,8 @@ add_callback (const char *type, const char *path, void *fn, bool value, void *da
     }
     pthread_mutex_unlock (&lock);
 
-    if (sprintf (_path, "%s/%zX-%"PRIX64"-%zX",
-            type, (size_t)pid, cb->ref, (size_t)g_str_hash (path)) <= 0)
+    if (sprintf (_path, "%s/"APTERYX_GUID_FORMAT,
+            type, getns (), (uint64_t)pid, cb->ref, (uint64_t)g_str_hash (path)) <= 0)
         return false;
     if (!apteryx_set (_path, path))
         return false;
@@ -2079,8 +2079,8 @@ delete_callback (const char *type, const char *path, void *fn, void *data)
     free ((void *) cb->path);
     free (cb);
 
-    if (sprintf (_path, "%s/%zX-%"PRIX64"-%zX",
-            type, (size_t)getpid (), ref, (size_t)g_str_hash (path)) <= 0)
+    if (sprintf (_path, "%s/"APTERYX_GUID_FORMAT,
+            type, getns (), (uint64_t)getpid (), ref, (uint64_t)g_str_hash (path)) <= 0)
         return false;
     if (!apteryx_set (_path, NULL))
         return false;

--- a/config.c
+++ b/config.c
@@ -80,10 +80,10 @@ static cb_info_t *
 update_callback (struct callback_node *list, const char *guid, const char *value)
 {
     cb_info_t *cb;
-    uint64_t pid, callback, hash;
+    uint64_t ns, pid, callback, hash;
 
     /* Parse callback info from the encoded guid */
-    if (sscanf (guid, "%" PRIX64 "-%" PRIx64 "-%" PRIx64 "", &pid, &callback, &hash) != 3)
+    if (sscanf (guid, APTERYX_GUID_FORMAT, &ns, &pid, &callback, &hash) != 4)
     {
         ERROR ("Invalid GUID (%s)\n", guid ? : "NULL");
         return NULL;
@@ -116,7 +116,7 @@ update_callback (struct callback_node *list, const char *guid, const char *value
             cb_disable (cb);
             cb_release (cb);
         }
-        cb = cb_create (list, guid, value, pid, callback);
+        cb = cb_create (list, guid, value, pid, callback, ns);
 
         /* This will either replace the entry removed above, or add a new one. */
         pthread_rwlock_wrlock (&guid_lock);
@@ -417,55 +417,55 @@ config_init (void)
 
     /* Debug set */
     cb = cb_create (watch_list, "debug", APTERYX_DEBUG_PATH,
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_debug_set);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_debug_set, 0);
     cb_release (cb);
 
     /* Counters */
     cb = cb_create (index_list, "counters", APTERYX_COUNTERS "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_counters_index);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_counters_index, 0);
     cb_release (cb);
     cb = cb_create (provide_list, "counters", APTERYX_COUNTERS "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_counters_get);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_counters_get, 0);
     cb_release (cb);
 
     /* Statistics */
     cb = cb_create (refresh_list, "statistics", APTERYX_STATISTICS "/*",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_statistics_refresh);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_statistics_refresh, 0);
     cb_release (cb);
 
     /* Sockets */
     cb = cb_create (watch_list, "sockets", APTERYX_SOCKETS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_sockets_set);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_sockets_set, 0);
     cb_release (cb);
 
     /* Indexers */
     cb = cb_create (watch_list, "indexers", APTERYX_INDEXERS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_indexers_set);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_indexers_set, 0);
     cb_release (cb);
 
     /* Watchers */
     cb = cb_create (watch_list, "watchers", APTERYX_WATCHERS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_watchers_set);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_watchers_set, 0);
     cb_release (cb);
 
     /* Refeshers */
     cb = cb_create (watch_list, "refreshers", APTERYX_REFRESHERS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_refreshers_set);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_refreshers_set, 0);
     cb_release (cb);
 
     /* Providers */
     cb = cb_create (watch_list, "providers", APTERYX_PROVIDERS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_providers_set);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_providers_set, 0);
     cb_release (cb);
 
     /* Validators */
     cb = cb_create (watch_list, "validators", APTERYX_VALIDATORS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_validators_set);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_validators_set, 0);
     cb_release (cb);
 
     /* Proxies */
     cb = cb_create (watch_list, "proxies", APTERYX_PROXIES_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_proxies_set);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_proxies_set, 0);
     cb_release (cb);
     if (!cb)
     {

--- a/rpc.c
+++ b/rpc.c
@@ -123,7 +123,7 @@ worker_func (gpointer a, gpointer b)
             usleep (rand() & RPC_TEST_DELAY_MASK);
 
         /* Process the callback */
-        DEBUG ("RPC[%d]: processing message from %d\n", sock->sock, sock->pid);
+        DEBUG ("RPC[%d]: processing message from "APTERYX_CLIENT_ID"\n", sock->sock, sock->ns, sock->pid);
         if (!handler (msg))
         {
             DEBUG ("RPC[%i]: handler failed\n", sock->sock);
@@ -704,7 +704,7 @@ rpc_client_existing_s (rpc_instance rpc, const char *url)
                 rpc_socket sock = (rpc_socket) c->data;
                 if (sock->dead)
                     continue;
-                char *surl = g_strdup_printf ("%s.%d", server->url, sock->pid);
+                char *surl = g_strdup_printf ("%s."APTERYX_CLIENT_ID, server->url, sock->ns, sock->pid);
                 DEBUG ("Compare client: %s to %s\n", url, surl);
                 if (g_strcmp0 (url, surl) == 0)
                 {

--- a/rpc_socket.c
+++ b/rpc_socket.c
@@ -195,7 +195,7 @@ rpc_socket_recv (rpc_socket sock, rpc_id id, void **data, size_t *len, uint64_t 
 }
 
 rpc_socket
-rpc_socket_create (int fd, rpc_callback cb, rpc_server parent, int pid)
+rpc_socket_create (int fd, rpc_callback cb, rpc_server parent, int pid, uint64_t ns)
 {
     rpc_socket sock = g_malloc0 (sizeof(*sock));
     sock->refcount = 1;
@@ -207,6 +207,7 @@ rpc_socket_create (int fd, rpc_callback cb, rpc_server parent, int pid)
     sock->request_cb = cb;
     sock->parent = parent;
     sock->pid = pid;
+    sock->ns = ns;
     pthread_mutex_init (&sock->in_lock, NULL);
     pthread_mutex_init (&sock->out_lock, NULL);
     pthread_mutex_init (&sock->lock, NULL);

--- a/rpc_transport.h
+++ b/rpc_transport.h
@@ -35,7 +35,8 @@ struct rpc_socket_s {
     GList *in_queue;
     int waiting;
     bool dead;
-    int pid;
+    uint64_t pid;
+    uint64_t ns;
 };
 
 struct rpc_server_s {
@@ -90,7 +91,7 @@ rpc_socket rpc_socket_connect_service (const char *url, rpc_callback request_cal
 
 size_t rpc_socket_hdr_size (void);
 
-rpc_socket rpc_socket_create (int fd, rpc_callback cb, rpc_server parent, int pid);
+rpc_socket rpc_socket_create (int fd, rpc_callback cb, rpc_server parent, int pid, uint64_t ns);
 bool rpc_socket_process (rpc_socket sock);
 void rpc_socket_ref (rpc_socket sock);
 void rpc_socket_deref (rpc_socket sock);

--- a/test.c
+++ b/test.c
@@ -8350,7 +8350,7 @@ void
 test_rpc_fork ()
 {
     const char *path = TEST_PATH"/entity/zones/private/state";
-    char *filename = g_strdup_printf ("/tmp/apteryx.%"PRIu64, (uint64_t) getpid ());
+    char *filename = g_strdup_printf ("/tmp/apteryx."APTERYX_CLIENT_ID, getns (), (uint64_t) getpid ());
 
     /* Add a watcher so that the callback socket is created */
     CU_ASSERT (apteryx_watch (path, test_watch_callback));


### PR DESCRIPTION
Use helpers for unix socket paths and guid's to make ns additions easier.
Add ns to the guid, sockets and callbacks.
Get peer pid, nspid and ns from the socket when they connect. Match server sockets to client URL to allow socket reuse from a peer in a different namespace.