### PR TITLE
Verify lua provide response

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -977,7 +977,9 @@ lua_do_provide (const char *path, lua_callback_info *cb_info)
             lua_apteryx_error (L, res);
         if (lua_gettop (L))
         {
-            value = strdup (lua_apteryx_tostring (L, -1));
+            const char *v = lua_apteryx_tostring (L, -1);
+            if (v)
+                value = strdup (v);
             lua_pop (L, 1);
         }
         lua_pop (L, 1); /* pop fn */

--- a/test.c
+++ b/test.c
@@ -9152,6 +9152,42 @@ test_lua_basic_provide (void)
 }
 
 static int
+test_lua_provide_nil_thread (void *data)
+{
+    CU_ASSERT (_run_lua (
+            "apteryx = require('apteryx')                                 \n"
+            "function test_provide (path)                                   "
+            "    assert (path == '"TEST_PATH"/provide')                     "
+            "    return nil                                                 "
+            "end                                                          \n"
+            "apteryx.provide('"TEST_PATH"/provide', test_provide)         \n"
+            "for i=1,5 do                                                  "
+            "    apteryx.process()                                          "
+            "    os.execute('sleep 0.1')                                    "
+            "end                                                          \n"
+            "apteryx.unprovide('"TEST_PATH"/provide', test_provide)       \n"
+            "apteryx.process(false)                                       \n"
+    ));
+    return 0;
+}
+
+void
+test_lua_provide_nil (void)
+{
+    pthread_t client;
+    char *value = NULL;
+
+    pthread_create (&client, NULL, (void *) &test_lua_provide_nil_thread, (void *) NULL);
+    usleep (TEST_SLEEP_TIMEOUT);
+    CU_ASSERT ((value = apteryx_get (TEST_PATH"/provide")) == NULL);
+    if (value)
+        free ((void *) value);
+    pthread_join (client, NULL);
+    usleep (TEST_SLEEP_TIMEOUT);
+    CU_ASSERT (assert_apteryx_empty ());
+}
+
+static int
 test_lua_index_thread (void *data)
 {
     CU_ASSERT (_run_lua (
@@ -9759,6 +9795,7 @@ CU_TestInfo tests_lua[] = {
     { "lua watch delayed thrash", test_lua_watch_delayed_thrash },
     { "lua basic refresh", test_lua_basic_refresh },
     { "lua basic provide", test_lua_basic_provide },
+    { "lua provide nil", test_lua_provide_nil },
     { "lua basic index", test_lua_basic_index },
     { "lua basic validate", test_lua_basic_validate },
     { "lua load memory usage", test_lua_load_memory },


### PR DESCRIPTION
If a lua provider returns 'nil' we should check and return a null pointer.