### PR TITLE
Add missing instance unlock

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -1102,6 +1102,7 @@ lua_apteryx_mainloop (lua_State *L)
     }
 
     running = true;
+    lua_apteryx_instance_unlock (L);
     while (running && fd >= 0)
     {
         g_L = L;


### PR DESCRIPTION
When using the apteryx mainloop from lua directly (not via Alfred) the instance must be unlocked to hand control of the state over to the library to use.