### PR TITLE
Tune lua garbage collector in alfred

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -1233,6 +1233,13 @@ luaopen_libapteryx (lua_State *L)
         lua_apteryx_instance_lock(L);
     }
 
+    /* Tune the garbage collector */
+#if LUA_VERSION_NUM >= 504
+    lua_gc (L, LUA_GCINC, 150, 100, 13);
+#elif LUA_VERSION_NUM == 503
+    lua_gc (L, LUA_GCSETPAUSE, 150);
+#endif /* LUA_VERSION_NUM */
+    
     /* Return the Apteryx object on the stack */
     luaL_newmetatable (L, "apteryx");
     luaL_setfuncs (L, _apteryx_fns, 0);


### PR DESCRIPTION
The default values for the garbage collector in alfred can result in an ever-growing pile of garbage when repeated provide calls are made.

Tune the garbage collector by reducing the pause value from the default 200 to 150 - the GC runs more frequently and prevents the pile from building up nearly as high.

The lua_gc API differs between lua 5.3 and 5.4.