### PR TITLE
Fix local refresher for statistics

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -592,6 +592,12 @@ call_refreshers (const char *path, bool dry_run)
             timeout = cb (cpath);
             if (refresher->timeout == 0 || timeout < refresher->timeout)
                 refresher->timeout = timeout;
+            /* Record the last time we ran this refresher */
+            refresher->timestamp = now;
+            /* Record the path we refreshed (without any trailing /'s)*/
+            if (refresher->last_path)
+                free (refresher->last_path);
+            refresher->last_path = g_strdup (cpath);
             goto unlock;
         }
 

--- a/config.c
+++ b/config.c
@@ -282,7 +282,7 @@ _statistics_fn (gpointer data, gpointer user_data)
     if (cb->count)
         avg = (int)(GET_COUNTER(cb->total)/GET_COUNTER(cb->count));
     value = g_strdup_printf ("%u,%u,%u,%u", GET_COUNTER(cb->count), GET_COUNTER(cb->min), avg, GET_COUNTER(cb->max));
-    db_add (path, (const unsigned char *)value, strlen (value) + 1, get_time_us ());
+    db_add (path, (const unsigned char *)value, strlen (value) + 1, UINT64_MAX);
     g_free (path);
     g_free (value);
 }


### PR DESCRIPTION
We should record the timestamp and last path on any local refreshers.

We dont need to specify the CAS timestamp when adding stats to the DB, but using the wrong timestamp fn is even worse.

Currently the only local refresher is for statistics and this fix avoids the stats refresher being thrashed.