### PR TITLE
Implement apteryx_watch_tree_masked

### DIFF
--- a/apteryxc.c
+++ b/apteryxc.c
@@ -96,6 +96,7 @@ struct stat_t
     uint64_t pid;
     uint64_t callback;
     uint64_t ns;
+    uint64_t flags;
     uint64_t hash;
     uint64_t count;
     uint64_t min;
@@ -125,7 +126,7 @@ _parse_stats (GNode *node, gpointer data)
         struct stat_t *stat = g_malloc0 (sizeof (struct stat_t));
         stat->guid = g_strdup (APTERYX_NAME (node));
         if (sscanf (APTERYX_NAME (node), APTERYX_GUID_FORMAT,
-                    &stat->ns, &stat->pid, &stat->callback, &stat->hash) != 4 ||
+                    &stat->ns, &stat->pid, &stat->callback, &stat->flags, &stat->hash) != 5 ||
             sscanf (APTERYX_VALUE (node), "%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "",
                     &stat->count, &stat->min, &stat->avg, &stat->max) != 4 ||
             stat->count == 0)

--- a/callbacks.c
+++ b/callbacks.c
@@ -36,7 +36,7 @@ static pthread_mutex_t tree_lock = PTHREAD_MUTEX_INITIALIZER;
 
 cb_info_t *
 cb_create (struct callback_node *tree_root, const char *guid, const char *path,
-           uint64_t id, uint64_t callback, uint64_t ns)
+           uint64_t id, uint64_t callback, uint64_t ns, uint64_t flags)
 {
     cb_info_t *cb = (cb_info_t *) g_malloc0 (sizeof (cb_info_t));
     cb->active = true;
@@ -46,6 +46,7 @@ cb_create (struct callback_node *tree_root, const char *guid, const char *path,
     cb->id = id;
     cb->uri = g_strdup_printf (APTERYX_CLIENT, cb->ns, cb->id);
     cb->ref = callback;
+    cb->flags = flags;
     g_atomic_int_set (&cb->refcnt, 1);
 
     g_atomic_int_inc (&cb->refcnt);
@@ -643,7 +644,7 @@ test_cb_match ()
     cb_info_t *cb = NULL;
     /* Wildcard in path */
     struct callback_node *watches_list = cb_init ();
-    cb = cb_create (watches_list, "tester", "/firewall/rules/*/app", 1, 0, 0);
+    cb = cb_create (watches_list, "tester", "/firewall/rules/*/app", 1, 0, 0, 0);
     cb_release (cb);
     matches = cb_match (watches_list, "/firewall/rules/10/app");
     CU_ASSERT (matches != NULL);
@@ -658,7 +659,7 @@ test_cb_match ()
 
     /* directory */
     watches_list = cb_init ();
-    cb = cb_create (watches_list, "tester", "/firewall/rules/10/", 2, 0, 0);
+    cb = cb_create (watches_list, "tester", "/firewall/rules/10/", 2, 0, 0, 0);
     cb_release (cb);
 
     matches = cb_match (watches_list, "/firewall/rules/10/app");
@@ -673,7 +674,7 @@ test_cb_match ()
     cb_shutdown (watches_list);
 
     watches_list = cb_init ();
-    cb = cb_create (watches_list, "tester", "/firewall/rules/10/app", 3, 0, 0);
+    cb = cb_create (watches_list, "tester", "/firewall/rules/10/app", 3, 0, 0, 0);
     cb_release (cb);
     matches = cb_match (watches_list, "/firewall/rules/10/app");
     CU_ASSERT (matches != NULL);
@@ -687,7 +688,7 @@ test_cb_match ()
     cb_shutdown (watches_list);
 
     watches_list = cb_init ();
-    cb = cb_create (watches_list, "tester", "/firewall/rules/10", 4, 0, 0);
+    cb = cb_create (watches_list, "tester", "/firewall/rules/10", 4, 0, 0, 0);
     cb_release (cb);
 
     matches = cb_match (watches_list, "/firewall/rules/10/app");
@@ -701,7 +702,7 @@ test_cb_match ()
     cb_shutdown (watches_list);
 
     watches_list = cb_init ();
-    cb = cb_create (watches_list, "tester", "/firewall/rules/*", 5, 0, 0);
+    cb = cb_create (watches_list, "tester", "/firewall/rules/*", 5, 0, 0, 0);
     cb_release (cb);
 
     matches = cb_match (watches_list, "/firewall/rules/10/app");
@@ -725,7 +726,7 @@ test_cb_release ()
 {
     cb_info_t *cb;
     struct callback_node *watches_list = cb_init ();
-    cb = cb_create (watches_list, "abc", "/test", 1, 0, 0);
+    cb = cb_create (watches_list, "abc", "/test", 1, 0, 0, 0);
     cb_release (cb);
     CU_ASSERT (g_atomic_int_get (&cb->refcnt) == 1);
     cb_release (cb);
@@ -738,7 +739,7 @@ test_cb_disable ()
 {
     cb_info_t *cb;
     struct callback_node *watches_list = cb_init ();
-    cb = cb_create (watches_list, "abc", "/test", 1, 0, 0);
+    cb = cb_create (watches_list, "abc", "/test", 1, 0, 0, 0);
 
     cb_disable (cb);
     CU_ASSERT (!hashtree_empty (&watches_list->hashtree_node));
@@ -770,7 +771,7 @@ match_perf_test (PERF_TEST_INDEX index)
     {
         sprintf (path, "/database/test%d/test%d", i, i);
         sprintf (guid, "%zX", (size_t) g_str_hash (path));
-        cb = cb_create (watches_list, guid, path, 1, 0, 0);
+        cb = cb_create (watches_list, guid, path, 1, 0, 0, 0);
         cb_release (cb);
     }
     CU_ASSERT (!hashtree_empty (&watches_list->hashtree_node));
@@ -821,7 +822,7 @@ _cb_exist_locking_thrasher (void *list)
     while (test_running)
     {
         cb_info_t *cb =
-            cb_create (test_list, "tester", "/test/callback/path/down/*/someplace", 1, 0, 0);
+            cb_create (test_list, "tester", "/test/callback/path/down/*/someplace", 1, 0, 0, 0);
         cb_release (cb);
         /* remove this callback */
         cb_release (cb);

--- a/config.c
+++ b/config.c
@@ -80,10 +80,10 @@ static cb_info_t *
 update_callback (struct callback_node *list, const char *guid, const char *value)
 {
     cb_info_t *cb;
-    uint64_t ns, pid, callback, hash;
+    uint64_t ns, pid, callback, flags, hash;
 
     /* Parse callback info from the encoded guid */
-    if (sscanf (guid, APTERYX_GUID_FORMAT, &ns, &pid, &callback, &hash) != 4)
+    if (sscanf (guid, APTERYX_GUID_FORMAT, &ns, &pid, &callback, &flags, &hash) != 5)
     {
         ERROR ("Invalid GUID (%s)\n", guid ? : "NULL");
         return NULL;
@@ -116,7 +116,7 @@ update_callback (struct callback_node *list, const char *guid, const char *value
             cb_disable (cb);
             cb_release (cb);
         }
-        cb = cb_create (list, guid, value, pid, callback, ns);
+        cb = cb_create (list, guid, value, pid, callback, ns, flags);
 
         /* This will either replace the entry removed above, or add a new one. */
         pthread_rwlock_wrlock (&guid_lock);
@@ -417,55 +417,55 @@ config_init (void)
 
     /* Debug set */
     cb = cb_create (watch_list, "debug", APTERYX_DEBUG_PATH,
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_debug_set, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_debug_set, 0, 0);
     cb_release (cb);
 
     /* Counters */
     cb = cb_create (index_list, "counters", APTERYX_COUNTERS "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_counters_index, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_counters_index, 0, 0);
     cb_release (cb);
     cb = cb_create (provide_list, "counters", APTERYX_COUNTERS "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_counters_get, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_counters_get, 0, 0);
     cb_release (cb);
 
     /* Statistics */
     cb = cb_create (refresh_list, "statistics", APTERYX_STATISTICS "/*",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_statistics_refresh, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_statistics_refresh, 0, 0);
     cb_release (cb);
 
     /* Sockets */
     cb = cb_create (watch_list, "sockets", APTERYX_SOCKETS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_sockets_set, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_sockets_set, 0, 0);
     cb_release (cb);
 
     /* Indexers */
     cb = cb_create (watch_list, "indexers", APTERYX_INDEXERS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_indexers_set, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_indexers_set, 0, 0);
     cb_release (cb);
 
     /* Watchers */
     cb = cb_create (watch_list, "watchers", APTERYX_WATCHERS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_watchers_set, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_watchers_set, 0, 0);
     cb_release (cb);
 
     /* Refeshers */
     cb = cb_create (watch_list, "refreshers", APTERYX_REFRESHERS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_refreshers_set, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_refreshers_set, 0, 0);
     cb_release (cb);
 
     /* Providers */
     cb = cb_create (watch_list, "providers", APTERYX_PROVIDERS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_providers_set, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_providers_set, 0, 0);
     cb_release (cb);
 
     /* Validators */
     cb = cb_create (watch_list, "validators", APTERYX_VALIDATORS_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_validators_set, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_validators_set, 0, 0);
     cb_release (cb);
 
     /* Proxies */
     cb = cb_create (watch_list, "proxies", APTERYX_PROXIES_PATH "/",
-                    (uint64_t) getpid (), (uint64_t) (size_t) handle_proxies_set, 0);
+                    (uint64_t) getpid (), (uint64_t) (size_t) handle_proxies_set, 0, 0);
     cb_release (cb);
     if (!cb)
     {

--- a/internal.h
+++ b/internal.h
@@ -43,8 +43,8 @@
 #define APTERYX_CLIENT_ID   "%"PRIX64".%"PRIu64
 #define APTERYX_CLIENT      APTERYX_SERVER"."APTERYX_CLIENT_ID
 
-/* Callback GUID format <namespace>-<nspid>-<client-reference>-<path-hash> */
-#define APTERYX_GUID_FORMAT     "%"PRIX64"-%"PRIu64"-%"PRIX64"-%"PRIX64""
+/* Callback GUID format <namespace>-<nspid>-<client-reference>-<flags>-<path-hash> */
+#define APTERYX_GUID_FORMAT     "%"PRIX64"-%"PRIu64"-%"PRIX64"-%"PRIX64"-%"PRIX64""
 
 /* Debug */
 extern bool apteryx_debug;
@@ -158,6 +158,7 @@ typedef struct _cb_info_t
     uint64_t ns;
     uint64_t id;
     uint64_t ref;
+    uint64_t flags;
 
     struct callback_node *node;
     int refcnt;
@@ -256,6 +257,9 @@ typedef struct rpc_message_t
     /* Data */
     size_t offset;
     size_t length;
+    /* Sender */
+    uint64_t ns;
+    uint64_t pid;
 } rpc_message_t;
 typedef struct rpc_message_t *rpc_message;
 typedef bool (*rpc_msg_handler) (rpc_message msg);
@@ -318,7 +322,7 @@ bool config_tree_has_validators (const char *path);
 /* Callbacks to clients */
 struct callback_node *cb_init (void);
 cb_info_t *cb_create (struct callback_node *list, const char *guid, const char *path,
-                      uint64_t id, uint64_t callback, uint64_t ns);
+                      uint64_t id, uint64_t callback, uint64_t ns, uint64_t flags);
 void cb_disable (cb_info_t *cb);
 void cb_take (cb_info_t *cb);
 void cb_release (cb_info_t *cb);
@@ -336,7 +340,7 @@ void cb_foreach (struct callback_node *list, GFunc func, gpointer user_data);
 void cb_shutdown (struct callback_node *root);
 
 /* Callbacks to users */
-bool add_callback (const char *type, const char *path, void *fn, bool value, void *data, uint32_t flags, uint64_t timeout_ms);
+bool add_callback (const char *type, const char *path, void *fn, bool value, void *data, uint64_t flags, uint64_t timeout_ms);
 bool delete_callback (const char *type, const char *path, void *fn, void *data);
 
 /* Tests */

--- a/rpc.c
+++ b/rpc.c
@@ -317,6 +317,8 @@ request_cb (rpc_socket sock, rpc_id id, void *buffer, size_t len)
     rpc_msg_push (&work->msg, len);
     memcpy (work->msg.buffer + work->msg.offset, buffer, len);
     work->msg.length = len;
+    work->msg.ns = sock->ns;
+    work->msg.pid = sock->pid;
 
     /* Sneak a peak to see if we can respond now */
     if (*(unsigned char*)buffer == MODE_WATCH)


### PR DESCRIPTION
Allows users to create a watch callback that masks sets made by itself as defined by namespace and pid.

Flags are now passed to apteryxd via the GUID.
RPC messages contain the sender ns/pid.
Use macros to alow users to activate the required
functionality without them calling the _full fn.