### PR TITLE
tests: don't try to sudo and set a value that doesn't exist

### DIFF
--- a/test.c
+++ b/test.c
@@ -8995,7 +8995,6 @@ test_socket_latency (int family, bool cd, bool req, bool resp)
     if (ret < 0)
         return;
 
-    CU_ASSERT (system ("sudo sysctl -w net.ipv4.tcp_tw_recycle=1 > /dev/null 2>&1 || true") == 0);
     if ((pid = fork ()) == 0)
     {
         if (!cd)
@@ -9060,7 +9059,6 @@ test_socket_latency (int family, bool cd, bool req, bool resp)
             close (s);
     }
 exit:
-    CU_ASSERT (system ("sudo sysctl -w net.ipv4.tcp_tw_recycle=0 > /dev/null 2>&1 || true") == 0);
     kill (pid, 9);
     waitpid (pid, &status, 0);
     if (family == AF_UNIX)


### PR DESCRIPTION
tcp_tw_recycle hasn't existed since 4.12, also it's a bit unfriendly to try to sudo