### PR TITLE
Return DB timestamp for refreshed paths

### DIFF
--- a/apteryxd.c
+++ b/apteryxd.c
@@ -2287,12 +2287,13 @@ handle_timestamp (rpc_message msg)
     if ((value = proxy_timestamp (path)) == 0)
     {
         /* Lookup value */
-        if (call_refreshers (path, true) || config_tree_has_providers (path))
+        if (config_tree_has_providers (path))
         {
             value = get_time_us ();
         }
         else
         {
+            call_refreshers (path, false);
             value = db_timestamp (path);
         }
     }

--- a/test.c
+++ b/test.c
@@ -8833,20 +8833,24 @@ test_timestamp_refreshed ()
     uint64_t ts, ts1;
     char *value;
 
-    _cb_timeout = 1000000;
+    _cb_timeout = 5000;
     apteryx_refresh(path, test_refresh_callback);
 
+    /* Getting the timestamp should call the refresher */
     ts = apteryx_timestamp (path);
     CU_ASSERT (ts != 0);
 
+    /* Refresher should not be called again and hence
+       the timestamp should not change */
     value = apteryx_get(path);
     ts1 = apteryx_timestamp (path);
+    CU_ASSERT(ts1 == ts);
 
-    CU_ASSERT(ts1 != 0);
-    CU_ASSERT(ts != ts1);
-
+    /* Getting the timestamp should call the refresher
+       as we have waited _cb_timeout */
+    usleep (_cb_timeout);
     ts = apteryx_timestamp (path);
-    CU_ASSERT(ts == ts1);
+    CU_ASSERT(ts != ts1);
 
     free (value);
     apteryx_unrefresh(path, test_refresh_callback);


### PR DESCRIPTION
Previously we alway returned "now" if there was a chance of a path being refreshed. That was because refreshed paths always had their timestamps updated to "now" even if the refresher decided not to update anything so that we did not call the refresher again for stale child nodes. Now that we do not use the DB timestamps to decide whether to call the refreshers anymore we can fix this odd behaviour.

The change in behaviour is;
1. A call to a refresher does not result in all children of the path having their timestamps set to "now" even if they were not modified.
2. A call to get a timestamp for a path will call refreshers to make sure the timestamp is up to date.