### PR TITLE
CR-85346: Update apteryx query assertions

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -1857,7 +1857,7 @@ apteryx_query (GNode *root)
      * used for get / set tree operations - value leaf nodes don't get created.
      * We need them for the encode tree, so add them now.
      */
-    ASSERT (root, return NULL, "QUERY: Invalid parameters\n");
+    ASSERT (root && root->data, return NULL, "QUERY: Invalid parameters\n");
     g_node_traverse (root, G_IN_ORDER, G_TRAVERSE_LEAVES, -1, add_null_data, NULL);
 
     query_result = apteryx_query_full (root);

--- a/test.c
+++ b/test.c
@@ -5060,6 +5060,14 @@ test_query_empty ()
 }
 
 void
+test_query_null_path()
+{
+    GNode *root = APTERYX_NODE (NULL, (char *) NULL);
+    CU_ASSERT (apteryx_query (root) == NULL);
+    g_node_destroy (root);
+}
+
+void
 test_query_basic ()
 {
     GNode *root = NULL;
@@ -10887,6 +10895,7 @@ static CU_TestInfo tests_api_tree[] = {
     { "query2node deep nodes", test_query2node_deep_nodes },
     { "query2node deep paths", test_query2node_deep_paths },
     { "query empty", test_query_empty },
+    { "query null path", test_query_null_path },
     { "query basic", test_query_basic},
     { "query subtree root", test_query_subtree_root},
     { "query one level", test_query_one_level},


### PR DESCRIPTION
When showing an incomplete nat rule router would crash, due to an invalid memory access. This was caused by having a validity check on an entity that does not exist resulting in an apteryx node with null data. This has been remedied by updating the assertion in the apteryx query func to return NULL when the node data is NULL. Preventing an invalid memory access when destroying the node.

Change-Id: Ie2f30a86439f20adeaf492c231d0740d7c70629f
Reviewed-by: Blair Steven <blair.steven@alliedtelesis.co.nz>