### PR TITLE
Trigger refreshers matching the path/* for timestamp gets

### DIFF
--- a/apteryx.h
+++ b/apteryx.h
@@ -220,7 +220,14 @@ int32_t apteryx_get_int_default (const char *path, const char *key, int32_t defl
 bool apteryx_has_value (const char *path);
 
 /**
- * Get the last change timestamp in monotonic time of a given path
+ * Get the last change timestamp in monotonic time of a given path.
+ *
+ * If the function is given an intermediate (branch) node the timestamp is that of the
+ * most recently updated child. Passing a trailing asterisk (e.g. "/test/values/*") will
+ * cause any refreshers below this part of the tree to be called.
+ *
+ * NOTE: This function may cause refreshers to be called.
+ *
  * @param path path to get the timestamp for
  * @return 0 if the path doesn't exist, last change timestamp in monotonic time otherwise
  */

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -2296,8 +2296,22 @@ handle_timestamp (rpc_message msg)
         }
         else
         {
-            call_refreshers (path, false);
-            value = db_timestamp (path);
+            char *plain;
+            size_t plen;
+
+            plen = strlen (path);
+            if (plen >= 2 && g_strcmp0 (&path[plen - 2], "/*") == 0)
+            {
+                plain = g_strndup (path, plen - 2);
+                refreshers_traverse (plain, cb_refresh, true);
+            }
+            else
+            {
+                plain = g_strdup (path);
+                call_refreshers (path, false);
+            }
+            value = db_timestamp (plain);
+            free (plain);
         }
     }
 

--- a/test.c
+++ b/test.c
@@ -9048,6 +9048,43 @@ test_timestamp_refreshed ()
     _cb_count = 0;
 }
 
+void
+test_timestamp_refreshed_wildcard ()
+{
+    const char *refresher_path = TEST_PATH"/this/is/a/prefix/timestamp/refreshed";
+    const char *path = TEST_PATH"/this";
+    uint64_t ts, ts1;
+
+    _cb_timeout = 5000;
+    apteryx_refresh (refresher_path, test_refresh_callback);
+
+    /* Getting the timestamp should call the refresher */
+    usleep (_cb_timeout);
+    ts = apteryx_timestamp (path);
+    ts1 = apteryx_timestamp (refresher_path);
+    CU_ASSERT (ts1 != 0);
+    CU_ASSERT (ts != ts1);
+
+    char *wild_card_paths[] = {
+        TEST_PATH"/this/*",
+        TEST_PATH"/this/is/*",
+        TEST_PATH"/this/is/a/*",
+        TEST_PATH"/this/is/a/prefix/*",
+        TEST_PATH"/this/is/a/prefix/timestamp/*",
+    };
+    for (size_t i = 0; i < 5; i++)
+    {
+        usleep (_cb_timeout);
+        ts = apteryx_timestamp (wild_card_paths[i]);
+        ts1 = apteryx_timestamp (refresher_path);
+        CU_ASSERT (ts == ts1);
+    }
+
+    apteryx_unrefresh (refresher_path, test_refresh_callback);
+    apteryx_prune (path);
+    _cb_count = 0;
+}
+
 static char*
 test_provide_timestamp (const char *path)
 {
@@ -10708,6 +10745,7 @@ static CU_TestInfo tests_api[] = {
     { "double fork", test_double_fork },
     { "timestamp", test_timestamp },
     { "timestamp refreshed", test_timestamp_refreshed },
+    { "timestamp refreshed wildcard", test_timestamp_refreshed_wildcard },
     { "timestamp provider", test_timestamp_provider },
     { "memuse", test_memuse },
     { "path to node", test_path_to_node },


### PR DESCRIPTION
Presently, timestamp gets call refreshers that match the path but miss the path/*.

Add a check for path/* to better support timestamp gets before a get tree.