### PR TITLE
refresh: put timed out process in the sin bin

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Processes that fail to respond in reasonable time will be put in the sin bin, and remain there until RPC_CLIENT_TIMEOUT_US has elasped twice. This will allow other clients to complete their transactions, even if something is blocking up all the apteryxd processing threads.