### PR TITLE
Trigger refreshers matching the path/* for timestamp gets

### DIFF
--- a/apteryx.h
+++ b/apteryx.h
@@ -220,7 +220,14 @@ int32_t apteryx_get_int_default (const char *path, const char *key, int32_t defl
 bool apteryx_has_value (const char *path);
 
 /**
- * Get the last change timestamp in monotonic time of a given path
+ * Get the last change timestamp in monotonic time of a given path.
+ *
+ * If the function is given an intermediate (branch) node the timestamp is that of the
+ * most recently updated child. Passing a trailing asterisk (e.g. "/test/values/*") will
+ * cause any refreshers below this part of the tree to be called.
+ *
+ * NOTE: This function may cause refreshers to be called.
+ *
  * @param path path to get the timestamp for
  * @return 0 if the path doesn't exist, last change timestamp in monotonic time otherwise
  */

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -2392,8 +2392,22 @@ handle_timestamp (rpc_message msg)
         }
         else
         {
-            call_refreshers (path, false);
-            value = db_timestamp (path);
+            char *plain;
+            size_t plen;
+
+            plen = strlen (path);
+            if (plen >= 2 && g_strcmp0 (&path[plen - 2], "/*") == 0)
+            {
+                plain = g_strndup (path, plen - 2);
+                refreshers_traverse (plain, cb_refresh, true);
+            }
+            else
+            {
+                plain = g_strdup (path);
+                call_refreshers (path, false);
+            }
+            value = db_timestamp (plain);
+            free (plain);
         }
     }
 


### PR DESCRIPTION
Presently, timestamp gets call refreshers that match the path but miss the path/*.

Add a check for path/* to better support timestamp gets before a get tree.