### PR TITLE
Support musl libc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ EXTRA_CSRC += test.c
 apteryx_CFLAGS += -DTEST
 apteryx_LDFLAGS += -lcunit
 endif
+ifneq ($(HAVE_MALLINFO2),no)
+apteryx_CFLAGS += -DHAVE_MALLINFO2
+endif
 
 all: $(BUILDDIR)/libapteryx.so $(BUILDDIR)/apteryx $(BUILDDIR)/apteryxd
 

--- a/apteryx.c
+++ b/apteryx.c
@@ -1682,7 +1682,7 @@ apteryx_get_tree (const char *path)
         while (chunk)
         {
             /* Got something left after this chunk - add an intermediate node */
-            if (strlen(ptr))
+            if (ptr && strlen(ptr))
             {
                 new_root = APTERYX_NODE (new_root, g_strdup(chunk));
             }

--- a/apteryxc.c
+++ b/apteryxc.c
@@ -301,8 +301,8 @@ main (int argc, char **argv)
     /* Handle SIGTERM/SIGINT/SIGPIPE gracefully */
     if (mode != MODE_TEST)
     {
-        signal (SIGTERM, (__sighandler_t) termination_handler);
-        signal (SIGINT, (__sighandler_t) termination_handler);
+        signal (SIGTERM, (sighandler_t) termination_handler);
+        signal (SIGINT, (sighandler_t) termination_handler);
     }
 
     switch (mode)

--- a/apteryxd.c
+++ b/apteryxd.c
@@ -23,7 +23,7 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/wait.h>
 #include <arpa/inet.h>
 #include <malloc.h>
@@ -2440,14 +2440,24 @@ handle_memuse (rpc_message msg)
     if (path[0] == '.' && path[1] == '\0')
     {
         /* Total memory in use */
+#ifdef HAVE_MALLINFO2
         struct mallinfo2 mi = mallinfo2 ();
         value = (unsigned int) (mi.uordblks) + (unsigned int) (mi.hblkhd);
+#else
+        /* FIXME: Implement */
+        value = 0;
+#endif
     }
     else if (path[0] == '.' && path[1] == '.' && path[2] == '\0')
     {
         /* Total memory allocated */
+#ifdef HAVE_MALLINFO2
         struct mallinfo2 mi = mallinfo2 ();
         value = (unsigned int) (mi.arena) + (unsigned int) (mi.hblkhd);
+#else
+        /* FIXME: Implement */
+        value = 0;
+#endif
     }
     else
         value = db_memuse (path);
@@ -2555,8 +2565,8 @@ main (int argc, char **argv)
     }
 
     /* Handle SIGTERM/SIGINT/SIGPIPE gracefully */
-    signal (SIGTERM, (__sighandler_t) termination_handler);
-    signal (SIGINT, (__sighandler_t) termination_handler);
+    signal (SIGTERM, (sighandler_t) termination_handler);
+    signal (SIGINT, (sighandler_t) termination_handler);
     signal (SIGPIPE, SIG_IGN);
 
     int child_ready[2] = { 0 };

--- a/lua.c
+++ b/lua.c
@@ -38,7 +38,7 @@
  * along with this library. If not, see <http://www.gnu.org/licenses/>
  */
 #ifdef HAVE_LUA
-#include <sys/poll.h>
+#include <poll.h>
 #include <lua.h>
 #include <lauxlib.h>
 #include "apteryx.h"
@@ -1099,8 +1099,8 @@ lua_apteryx_mainloop (lua_State *L)
     }
     if (lua_gettop (L) == 1 && lua_toboolean (L, 1))
     {
-        signal (SIGTERM, (__sighandler_t) termination_handler);
-        signal (SIGINT, (__sighandler_t) termination_handler);
+        signal (SIGTERM, (sighandler_t) termination_handler);
+        signal (SIGINT, (sighandler_t) termination_handler);
     }
 
     running = true;

--- a/test.c
+++ b/test.c
@@ -26,7 +26,7 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <sys/un.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <assert.h>
 #ifdef HAVE_LUA
 #include <lua.h>
@@ -49,6 +49,10 @@
 #define TEST_MESSAGE_SIZE   100
 #define TEST_SCHEMA_PATH    "/etc/apteryx/schema:."
 #define TEST_SCHEMA_FILE    "./test.xml"
+
+#ifndef PTHREAD_NULL
+#define PTHREAD_NULL ((pthread_t)-1)
+#endif
 
 static int _cb_count = 0;
 
@@ -2174,7 +2178,7 @@ test_watch_myself_blocked ()
 }
 
 
-static pthread_t watch_thread_id = -1;
+static pthread_t watch_thread_id = PTHREAD_NULL;
 static bool
 test_watch_callback_thread_info (const char *path, const char *value)
 {
@@ -2185,7 +2189,7 @@ test_watch_callback_thread_info (const char *path, const char *value)
 
     usleep(TEST_SLEEP_TIMEOUT / 100);
 
-    if (watch_thread_id == -1)
+    if (watch_thread_id == PTHREAD_NULL)
         watch_thread_id = pthread_self ();
     else
         CU_ASSERT (pthread_self() == watch_thread_id);
@@ -2205,7 +2209,7 @@ test_watch_ack_thread ()
 {
     const char *path = TEST_PATH"/entity/zones/private/state";
     _cb_count = 0;
-    watch_thread_id = -1;
+    watch_thread_id = PTHREAD_NULL;
     CU_ASSERT (apteryx_watch (path, test_watch_callback_thread_info));
     apteryx_set (path, "1");
     apteryx_set_wait (path, "2");
@@ -9689,7 +9693,7 @@ exit:
     rpc_shutdown (rpc);
 }
 
-static pthread_t single_thread = -1;
+static pthread_t single_thread = PTHREAD_NULL;
 static int
 _single_thread (void *data)
 {


### PR DESCRIPTION
Initial support for musl libc.

- Replaced <sys/poll.h> with <poll.h>.
- Replaced `__sighandler_t` with `sighandler_t`.
- Changed to use PTHREAD_NULL instead of an immediate value.
  - NOTE: PTHREAD_NULL is a part of POSIX.1-2024, so it may not be supported. Currently -1 is assigned, but it conflicts with PTHREAD_CANCELED in musl libc.
- Added ifdef directives to avoid using mallinfo2(3), which is a glibc extension.

I think it is necessary to add a configure script or similar processing to detect HAVE_MALLINFO2.