### PR TITLE
Fix build warnings exposed by newer GCC (-Werror)

### DIFF
--- a/apteryx.c
+++ b/apteryx.c
@@ -156,16 +156,16 @@ validate_path (const char *path, char **url)
     {
         if (url)
             *url = strdup (path);
-        char *tmp = strstr (path + 6, ":/");
-        if (!tmp)
+        const char *sep = strstr (path + 6, ":/");
+        if (!sep)
         {
             ERROR ("Invalid path (%s)!\n", path);
             return NULL;
         }
-        path = tmp + 1;
+        path = sep + 1;
         if (url)
         {
-            tmp = strstr (*url + 6, ":/");
+            char *tmp = strstr (*url + 6, ":/");
             if (tmp != NULL)
             {
                 tmp[0] = '\0';
@@ -187,7 +187,6 @@ handle_index (rpc_message msg)
     uint64_t ref;
     const char *path;
     GList *iter = NULL;
-    int i;
 
     /* Parse the parameters */
     ref = rpc_msg_decode_uint64 (msg);
@@ -201,7 +200,7 @@ handle_index (rpc_message msg)
 
     /* Return result */
     rpc_msg_reset (msg);
-    for (i = 0, iter = results; iter; iter = g_list_next (iter), i++)
+    for (iter = results; iter; iter = g_list_next (iter))
     {
         DEBUG ("         = %s\n", (char *) iter->data);
         rpc_msg_encode_string (msg, (char *)iter->data);

--- a/config.c
+++ b/config.c
@@ -260,7 +260,7 @@ X_FIELDS
 static char*
 handle_counters_get (const char *path)
 {
-    char *counter = strrchr (path, '/');
+    const char *counter = strrchr (path, '/');
     char *value = NULL;
 #define X(type, name) \
     if (strcmp ("/"#name, counter) == 0 && \

--- a/hashtree.h
+++ b/hashtree.h
@@ -1,7 +1,7 @@
 
 
 #ifndef _HASHTREE_H_
-#define _HASHTREE_H_H
+#define _HASHTREE_H_
 
 #include <glib.h>
 #include <stdbool.h>


### PR DESCRIPTION
These are pre-existing latent issues only flagged as errors by newer GCC (CI uses GCC 11; they surface on GCC 16). They block building the tree at all, so fix them first:

- hashtree.h: header guard #define did not match the #ifndef token (_HASHTREE_H_H vs _HASHTREE_H_), tripping -Wheader-guard.
- config.c, apteryx.c: strrchr/strstr on a const char* were assigned to char*, discarding const (-Wdiscarded-qualifiers). Use const pointers; the values are only read.
- apteryx.c handle_index(): drop the write-only loop counter i (-Wunused-but-set-variable).

No functional change.